### PR TITLE
Remove unnecessary semicolons at EOL in JS examples

### DIFF
--- a/ch1.md
+++ b/ch1.md
@@ -20,24 +20,24 @@ Let's start with a touch of insanity. Here is a seagull application. When flocks
 
 ```js
 var Flock = function(n) {
-  this.seagulls = n;
-};
+  this.seagulls = n
+}
 
 Flock.prototype.conjoin = function(other) {
-  this.seagulls += other.seagulls;
-  return this;
-};
+  this.seagulls += other.seagulls
+  return this
+}
 
 Flock.prototype.breed = function(other) {
-  this.seagulls = this.seagulls * other.seagulls;
-  return this;
-};
+  this.seagulls = this.seagulls * other.seagulls
+  return this
+}
 
-var flock_a = new Flock(4);
-var flock_b = new Flock(2);
-var flock_c = new Flock(0);
+var flock_a = new Flock(4)
+var flock_b = new Flock(2)
+var flock_c = new Flock(0)
 
-var result = flock_a.conjoin(flock_c).breed(flock_b).conjoin(flock_a.breed(flock_b)).seagulls;
+var result = flock_a.conjoin(flock_c).breed(flock_b).conjoin(flock_a.breed(flock_b)).seagulls
 //=> 32
 ```
 
@@ -48,14 +48,14 @@ If you don't understand this program, it's okay, neither do I. The point is that
 Let's try again with a more functional approach:
 
 ```js
-var conjoin = function(flock_x, flock_y) { return flock_x + flock_y };
-var breed = function(flock_x, flock_y) { return flock_x * flock_y };
+var conjoin = function(flock_x, flock_y) { return flock_x + flock_y }
+var breed = function(flock_x, flock_y) { return flock_x * flock_y }
 
-var flock_a = 4;
-var flock_b = 2;
-var flock_c = 0;
+var flock_a = 4
+var flock_b = 2
+var flock_c = 0
 
-var result = conjoin(breed(flock_b, conjoin(flock_a, flock_c)), breed(flock_a, flock_b));
+var result = conjoin(breed(flock_b, conjoin(flock_a, flock_c)), breed(flock_a, flock_b))
 //=>16
 ```
 
@@ -64,43 +64,43 @@ Well, we got the right answer this time. There's much less code. The function ne
 There's really nothing special at all about these two functions other than their names. Let's rename our custom functions to reveal their true identity.
 
 ```js
-var add = function(x, y) { return x + y };
-var multiply = function(x, y) { return x * y };
+var add = function(x, y) { return x + y }
+var multiply = function(x, y) { return x * y }
 
-var flock_a = 4;
-var flock_b = 2;
-var flock_c = 0;
+var flock_a = 4
+var flock_b = 2
+var flock_c = 0
 
-var result = add(multiply(flock_b, add(flock_a, flock_c)), multiply(flock_a, flock_b));
+var result = add(multiply(flock_b, add(flock_a, flock_c)), multiply(flock_a, flock_b))
 //=>16
 ```
 And with that, we gain the knowledge of the ancients:
 
 ```js
 // associative
-add(add(x, y), z) == add(x, add(y, z));
+add(add(x, y), z) == add(x, add(y, z))
 
 // commutative
-add(x, y) == add(y, x);
+add(x, y) == add(y, x)
 
 // identity
-add(x, 0) == x;
+add(x, 0) == x
 
 // distributive
-multiply(x, add(y,z)) == add(multiply(x, y), multiply(x, z));
+multiply(x, add(y,z)) == add(multiply(x, y), multiply(x, z))
 ```
 
 Ah yes, those old faithful mathematical properties should come in handy. Don't worry if you didn't know them right off the top of your head. For a lot of us, it's been a while since we've reviewed this information. Let's see if we can use these properties to simplify our little seagull program.
 
 ```js
 // Original line
-add(multiply(flock_b, add(flock_a, flock_c)), multiply(flock_a, flock_b));
+add(multiply(flock_b, add(flock_a, flock_c)), multiply(flock_a, flock_b))
 
 // Apply the identity property to remove the extra add (add(flock_a, flock_c) == flock_a)
-add(multiply(flock_b, flock_a), multiply(flock_a, flock_b));
+add(multiply(flock_b, flock_a), multiply(flock_a, flock_b))
 
 // Apply distributive property to achieve our result
-multiply(flock_b, add(flock_a, flock_a));
+multiply(flock_b, add(flock_a, flock_a))
 ```
 
 Brilliant! We didn't have to write a lick of custom code other than our calling function. We include `add` and `multiply` definitions here for completeness, but there is really no need to write them - we surely have an `add` and `multiply` provided by some previously written library.

--- a/ch2.md
+++ b/ch2.md
@@ -7,34 +7,34 @@ That is JavaScript 101, but worth a mention as a quick code search on github wil
 
 ```js
 var hi = function(name){
-  return "Hi " + name;
-};
+  return "Hi " + name
+}
 
 var greeting = function(name) {
-  return hi(name);
-};
+  return hi(name)
+}
 ```
 
 Here, the function wrapper around `hi` in `greeting` is completely redundant. Why? Because functions are *callable* in JavaScript. When `hi` has the `()` at the end it will run and return a value. When it does not, it simply returns the function stored in the variable. Just to be sure, have a look-see:
 
 
 ```js
-hi;
+hi
 // function(name){
 //  return "Hi " + name
 // }
 
-hi("jonas");
+hi("jonas")
 // "Hi jonas"
 ```
 
 Since `greeting` is merely turning around and calling `hi` with the very same argument, we could simply write:
 
 ```js
-var greeting = hi;
+var greeting = hi
 
 
-greeting("times");
+greeting("times")
 // "Hi times"
 ```
 
@@ -46,12 +46,12 @@ A solid understanding of this is critical before moving on, so let's see a few m
 // ignorant
 var getServerStuff = function(callback){
   return ajaxCall(function(json){
-    return callback(json);
-  });
-};
+    return callback(json)
+  })
+}
 
 // enlightened
-var getServerStuff = ajaxCall;
+var getServerStuff = ajaxCall
 ```
 
 The world is littered with ajax code exactly like this. Here is the reason both are equivalent:
@@ -59,16 +59,16 @@ The world is littered with ajax code exactly like this. Here is the reason both 
 ```js
 // this line
 return ajaxCall(function(json){
-  return callback(json);
-});
+  return callback(json)
+})
 
 // is the same as this line
-return ajaxCall(callback);
+return ajaxCall(callback)
 
 // so refactor getServerStuff
 var getServerStuff = function(callback){
-  return ajaxCall(callback);
-};
+  return ajaxCall(callback)
+}
 
 // ...which is equivalent to this
 var getServerStuff = ajaxCall; // <-- look mum, no ()'s
@@ -79,33 +79,33 @@ And that, folks, is how it is done. Once more then we'll see why I'm so insisten
 ```js
 var BlogController = (function() {
   var index = function(posts) {
-    return Views.index(posts);
-  };
+    return Views.index(posts)
+  }
 
   var show = function(post) {
-    return Views.show(post);
-  };
+    return Views.show(post)
+  }
 
   var create = function(attrs) {
-    return Db.create(attrs);
-  };
+    return Db.create(attrs)
+  }
 
   var update = function(post, attrs) {
-    return Db.update(post, attrs);
-  };
+    return Db.update(post, attrs)
+  }
 
   var destroy = function(post) {
-    return Db.destroy(post);
-  };
+    return Db.destroy(post)
+  }
 
-  return {index: index, show: show, create: create, update: update, destroy: destroy};
-})();
+  return {index: index, show: show, create: create, update: update, destroy: destroy}
+})()
 ```
 
 This ridiculous controller is 99% fluff. We could either rewrite it as:
 
 ```js
-var BlogController = {index: Views.index, show: Views.show, create: Db.create, update: Db.update, destroy: Db.destroy};
+var BlogController = {index: Views.index, show: Views.show, create: Db.create, update: Db.update, destroy: Db.destroy}
 ```
 
 ...or scrap it altogether as it does nothing other than bundle our Views and Db together.
@@ -116,8 +116,8 @@ Okay, let's get down to the reasons to favor First class functions. As we saw in
 
 ```js
 httpGet('/post/2', function(json){
-  return renderPost(json);
-});
+  return renderPost(json)
+})
 ```
 
 If `httpGet` were to change to send a possible `err`, we would need to go back and change the "glue".
@@ -125,8 +125,8 @@ If `httpGet` were to change to send a possible `err`, we would need to go back a
 ```js
 // go back to every httpGet call in the application and explicitly pass err along.
 httpGet('/post/2', function(json, err){
-  return renderPost(json, err);
-});
+  return renderPost(json, err)
+})
 ```
 
 Had we written it as a first class function, much less would need to change:
@@ -141,16 +141,16 @@ Besides the removal of unnecessary functions, we must name and reference argumen
 // specific to our current blog
 var validArticles = function(articles) {
   return articles.filter(function(article){
-    return article !== null && article !== undefined;
-  });
-};
+    return article !== null && article !== undefined
+  })
+}
 
 // vastly more relevant for future projects
 var compact = function(xs) {
   return xs.filter(function(x) {
-    return x !== null && x !== undefined;
-  });
-};
+    return x !== null && x !== undefined
+  })
+}
 ```
 
 By naming things, we've seemingly tied ourselves to specific data (in this case `articles`). This happens quite a bit and is a source of much reinvention.
@@ -158,13 +158,13 @@ By naming things, we've seemingly tied ourselves to specific data (in this case 
 I must mention that, just like with Object-Oriented code, you must be aware of `this` coming to bite you in the jugular. If an underlying function uses `this` and we call it first class, we are subject to this leaky abstraction's wrath.
 
 ```js
-var fs = require('fs');
+var fs = require('fs')
 
 // scary
-fs.readFile('freaky_friday.txt', Db.save);
+fs.readFile('freaky_friday.txt', Db.save)
 
 // less so
-fs.readFile('freaky_friday.txt', Db.save.bind(Db));
+fs.readFile('freaky_friday.txt', Db.save.bind(Db))
 
 ```
 

--- a/ch3.md
+++ b/ch3.md
@@ -9,27 +9,27 @@ One thing we need to get straight is the idea of a pure function.
 Take `slice` and `splice`. They are two functions that do the exact same thing - in a vastly different way, mind you, but the same thing nonetheless. We say `slice` is *pure* because it returns the same output per input every time, guaranteed. `splice`, however, will chew up its array and spit it back out forever changed which is an observable effect.
 
 ```js
-var xs = [1,2,3,4,5];
+var xs = [1,2,3,4,5]
 
 // pure
-xs.slice(0,3);
+xs.slice(0,3)
 //=> [1,2,3]
 
-xs.slice(0,3);
+xs.slice(0,3)
 //=> [1,2,3]
 
-xs.slice(0,3);
+xs.slice(0,3)
 //=> [1,2,3]
 
 
 // impure
-xs.splice(0,3);
+xs.splice(0,3)
 //=> [1,2,3]
 
-xs.splice(0,3);
+xs.splice(0,3)
 //=> [4,5]
 
-xs.splice(0,3);
+xs.splice(0,3)
 //=> []
 ```
 
@@ -39,19 +39,19 @@ Let's look at another example.
 
 ```js
 // impure
-var minimum = 21;
+var minimum = 21
 
 var checkAge = function(age) {
-  return age >= minimum;
-};
+  return age >= minimum
+}
 
 
 
 // pure
 var checkAge = function(age) {
-  var minimum = 21;
-  return age >= minimum;
-};
+  var minimum = 21
+  return age >= minimum
+}
 ```
 
 In the impure portion, `checkAge` depends on the mutable variable `minimum` to determine the result. In other words, it depends on system state which is disappointing because it increases the cognitive load by introducing an external environment.
@@ -63,7 +63,7 @@ Its pure form, on the other hand, is completely self sufficient. We can  also ma
 ```js
 var immutableState = Object.freeze({
   minimum: 21
-});
+})
 ```
 
 ## Side effects may include...
@@ -121,14 +121,14 @@ Or even as a graph with `x` as the input and `y` as the output:
 There's no need for implementation details if the input dictates the output. Since functions are simply mappings of input to output, one could simply jot down object literals and run them with `[]` instead of `()`.
 
 ```js
-var toLowerCase = {"A":"a", "B": "b", "C": "c", "D": "d", "E": "e", "D": "d"};
+var toLowerCase = {"A":"a", "B": "b", "C": "c", "D": "d", "E": "e", "D": "d"}
 
-toLowerCase["C"];
+toLowerCase["C"]
 //=> "c"
 
-var isPrime = {1:false, 2: true, 3: true, 4: false, 5: true, 6:false};
+var isPrime = {1:false, 2: true, 3: true, 4: false, 5: true, 6:false}
 
-isPrime[3];
+isPrime[3]
 //=> true
 ```
 
@@ -143,15 +143,15 @@ Here comes the dramatic reveal: Pure functions *are* mathematical functions and 
 For starters, pure functions can always be cached by input. This is typically done using a technique called memoization:
 
 ```js
-var squareNumber  = memoize(function(x){ return x*x; });
+var squareNumber  = memoize(function(x){ return x*x; })
 
-squareNumber(4);
+squareNumber(4)
 //=> 16
 
 squareNumber(4); // returns cache for input 4
 //=> 16
 
-squareNumber(5);
+squareNumber(5)
 //=> 25
 
 squareNumber(5); // returns cache for input 5
@@ -162,14 +162,14 @@ Here is a simplified implementation, though there are plenty of more robust vers
 
 ```js
 var memoize = function(f) {
-  var cache = {};
+  var cache = {}
 
   return function() {
-    var arg_str = JSON.stringify(arguments);
-    cache[arg_str] = cache[arg_str] || f.apply(f, arguments);
-    return cache[arg_str];
-  };
-};
+    var arg_str = JSON.stringify(arguments)
+    cache[arg_str] = cache[arg_str] || f.apply(f, arguments)
+    return cache[arg_str]
+  }
+}
 ```
 
 Something to note is that you can transform some impure functions into pure ones by delaying evaluation:
@@ -177,7 +177,7 @@ Something to note is that you can transform some impure functions into pure ones
 ```js
 var pureHttpCall = memoize(function(url, params){
   return function() { return $.getJSON(url, params); }
-});
+})
 ```
 
 The interesting thing here is that we don't actually make the http call - we instead return a function that will do so when called. This function is pure because it will always return the same output given the same input: the function that will make the particular http call given the `url` and `params`.
@@ -193,17 +193,17 @@ Pure functions are completely self contained. Everything the function needs is h
 ```js
 //impure
 var signUp = function(attrs) {
-  var user = saveUser(attrs);
-  welcomeUser(user);
-};
+  var user = saveUser(attrs)
+  welcomeUser(user)
+}
 
 //pure
 var signUp = function(Db, Email, attrs) {
   return function() {
-    var user = saveUser(Db, attrs);
-    welcomeUser(Email, user);
-  };
-};
+    var user = saveUser(Db, attrs)
+    welcomeUser(Email, user)
+  }
+}
 ```
 
 The example here demonstrates that the pure function must be honest about its dependencies and, as such, tell us exactly what it's up to. Just from its signature, we know that it will use a `Db`, `Email`, and `attrs` which should be telling to say the least.
@@ -233,25 +233,25 @@ Since pure functions always return the same output given the same input, we can 
 ```js
 
 var decrementHP = function(player) {
-  return player.set("hp", player.hp-1);
-};
+  return player.set("hp", player.hp-1)
+}
 
 var isSameTeam = function(player1, player2) {
-  return player1.team === player2.team;
-};
+  return player1.team === player2.team
+}
 
 var punch = function(player, target) {
   if(isSameTeam(player, target)) {
-    return target;
+    return target
   } else {
-    return decrementHP(target);
+    return decrementHP(target)
   }
-};
+}
 
-var jobe = Immutable.Map({name:"Jobe", hp:20, team: "red"});
-var michael = Immutable.Map({name:"Michael", hp:20, team: "green"});
+var jobe = Immutable.Map({name:"Jobe", hp:20, team: "red"})
+var michael = Immutable.Map({name:"Michael", hp:20, team: "green"})
 
-punch(jobe, michael);
+punch(jobe, michael)
 //=> Immutable.Map({name:"Michael", hp:19, team: "green"})
 ```
 
@@ -262,11 +262,11 @@ First we'll inline the function `isSameTeam`.
 ```js
 var punch = function(player, target) {
   if(player.team === target.team) {
-    return target;
+    return target
   } else {
-    return decrementHP(target);
+    return decrementHP(target)
   }
-};
+}
 ```
 
 Since our data is immutable, we can simply replace the teams with their actual value
@@ -274,19 +274,19 @@ Since our data is immutable, we can simply replace the teams with their actual v
 ```js
 var punch = function(player, target) {
   if("red" === "green") {
-    return target;
+    return target
   } else {
-    return decrementHP(target);
+    return decrementHP(target)
   }
-};
+}
 ```
 
 We see that it is false in this case so we can remove the entire if branch
 
 ```js
 var punch = function(player, target) {
-  return decrementHP(target);
-};
+  return decrementHP(target)
+}
 
 ```
 
@@ -294,8 +294,8 @@ And if we inline `decrementHP`, we see that, in this case, punch becomes a call 
 
 ```js
 var punch = function(player, target) {
-  return target.set("hp", target.hp-1);
-};
+  return target.set("hp", target.hp-1)
+}
 ```
 
 This ability to reason about code is terrific for refactoring and understanding code in general. In fact, we used this technique to refactor our flock of seagulls program. We used equational reasoning to harness the properties of addition and multiplication. Indeed, we'll be using these techniques throughout the book.

--- a/ch4.md
+++ b/ch4.md
@@ -10,17 +10,17 @@ You can choose to call it all at once or simply feed in each argument piecemeal.
 ```js
 var add = function(x) {
   return function(y) {
-    return x + y;
-  };
-};
+    return x + y
+  }
+}
 
-var increment = add(1);
-var addTen = add(10);
+var increment = add(1)
+var addTen = add(10)
 
-increment(2);
+increment(2)
 // 3
 
-addTen(2);
+addTen(2)
 // 12
 ```
 
@@ -29,59 +29,59 @@ Here we've made a function `add` that will take one argument and return a functi
 Let's setup a few curried functions for our enjoyment.
 
 ```js
-var curry = require('lodash.curry');
+var curry = require('lodash.curry')
 
 var match = curry(function(what, x) {
-  return x.match(what);
-});
+  return x.match(what)
+})
 
 var replace = curry(function(what, replacement, x) {
-  return x.replace(what, replacement);
-});
+  return x.replace(what, replacement)
+})
 
 var filter = curry(function(f, xs) {
-  return xs.filter(f);
-});
+  return xs.filter(f)
+})
 
 var map = curry(function(f, xs) {
-  return xs.map(f);
-});
+  return xs.map(f)
+})
 ```
 
 The pattern I've followed is a simple, but important one. I've strategically positioned the data we're operating on (String, Array) as the last argument. It will become clear as to why upon use.
 
 ```js
-match(/\s+/g, "hello world");
+match(/\s+/g, "hello world")
 // [ ' ' ]
 
-match(/\s+/g)("hello world");
+match(/\s+/g)("hello world")
 // [ ' ' ]
 
-var hasSpaces = match(/\s+/g);
+var hasSpaces = match(/\s+/g)
 // function(x) { return x.match(/\s+/g) }
 
-hasSpaces("hello world");
+hasSpaces("hello world")
 // [ ' ' ]
 
-hasSpaces("spaceless");
+hasSpaces("spaceless")
 // null
 
-filter(hasSpaces, ["tori_spelling", "tori amos"]);
+filter(hasSpaces, ["tori_spelling", "tori amos"])
 // ["tori amos"]
 
-var findSpaces = filter(hasSpaces);
+var findSpaces = filter(hasSpaces)
 // function(xs) { return xs.filter(function(x) { return x.match(/\s+/g) }) }
 
-findSpaces(["tori_spelling", "tori amos"]);
+findSpaces(["tori_spelling", "tori amos"])
 // ["tori amos"]
 
-var noVowels = replace(/[aeiou]/ig);
+var noVowels = replace(/[aeiou]/ig)
 // function(replacement, x) { return x.replace(/[aeiou]/ig, replacement) }
 
-var censored = noVowels("*");
+var censored = noVowels("*")
 // function(x) { return x.replace(/[aeiou]/ig, "*") }
 
-censored("Chocolate Rain");
+censored("Chocolate Rain")
 // 'Ch*c*l*t* R**n'
 ```
 
@@ -96,18 +96,18 @@ We also have the ability to transform any function that works on single elements
 
 ```js
 var getChildren = function(x) {
-  return x.childNodes;
-};
+  return x.childNodes
+}
 
-var allTheChildren = map(getChildren);
+var allTheChildren = map(getChildren)
 ```
 
 Giving a function fewer arguments than it expects is typically called *partial application*. Partially applying a function can remove a lot of boiler plate code. Consider what the above `allTheChildren` function would be with the uncurried `map` from lodash[^note the arguments are in a different order]:
 
 ```js
 var allTheChildren = function(elements) {
-  return _.map(elements, getChildren);
-};
+  return _.map(elements, getChildren)
+}
 ```
 
 We typically don't define functions that work on arrays, because we can just call `map(getChildren)` inline. Same with `sort`, `filter`, and other higher order functions[^Higher order function: A function that takes or returns a function].
@@ -133,7 +133,7 @@ A quick word before we start. We'll use a library called *ramda* which curries e
 Answers are provided with the code in the [repository for this book](https://github.com/DrBoolean/mostly-adequate-guide/tree/master/code/part1_exercises/answers)
 
 ```js
-var _ = require('ramda');
+var _ = require('ramda')
 
 
 // Exercise 1
@@ -141,14 +141,14 @@ var _ = require('ramda');
 // Refactor to remove all arguments by partially applying the function
 
 var words = function(str) {
-  return _.split(' ', str);
-};
+  return _.split(' ', str)
+}
 
 // Exercise 1a
 //==============
 // Use map to make a new words fn that works on an array of strings.
 
-var sentences = undefined;
+var sentences = undefined
 
 
 // Exercise 2
@@ -156,8 +156,8 @@ var sentences = undefined;
 // Refactor to remove all arguments by partially applying the functions
 
 var filterQs = function(xs) {
-  return _.filter(function(x){ return match(/q/i, x);  }, xs);
-};
+  return _.filter(function(x){ return match(/q/i, x);  }, xs)
+}
 
 
 // Exercise 3
@@ -165,25 +165,25 @@ var filterQs = function(xs) {
 // Use the helper function _keepHighest to refactor max to not reference any arguments
 
 // LEAVE BE:
-var _keepHighest = function(x,y){ return x >= y ? x : y; };
+var _keepHighest = function(x,y){ return x >= y ? x : y; }
 
 // REFACTOR THIS ONE:
 var max = function(xs) {
   return _.reduce(function(acc, x){
-    return _keepHighest(acc, x);
-  }, 0, xs);
-};
+    return _keepHighest(acc, x)
+  }, 0, xs)
+}
 
   
 // Bonus 1:
 // ============
 // wrap array's slice to be functional and curried.
 // //[1,2,3].slice(0, 2)
-var slice = undefined;
+var slice = undefined
 
 
 // Bonus 2:
 // ============
 // use slice to define a function "take" that takes n elements. Make it curried
-var take = undefined;
+var take = undefined
 ```

--- a/ch5.md
+++ b/ch5.md
@@ -7,9 +7,9 @@ Here's `compose`:
 ```js
 var compose = function(f,g) {
   return function(x) {
-    return f(g(x));
-  };
-};
+    return f(g(x))
+  }
+}
 ```
 
 `f` and `g` are functions and `x` is the value being "piped" through them.
@@ -17,11 +17,11 @@ var compose = function(f,g) {
 Composition feels like function husbandry. You, breeder of functions, select two with traits you'd like to combine and mash them together to spawn a brand new one. Usage is as follows:
 
 ```js
-var toUpperCase = function(x) { return x.toUpperCase(); };
-var exclaim = function(x) { return x + '!'; };
-var shout = compose(exclaim, toUpperCase);
+var toUpperCase = function(x) { return x.toUpperCase(); }
+var exclaim = function(x) { return x + '!'; }
+var shout = compose(exclaim, toUpperCase)
 
-shout("send in the clowns");
+shout("send in the clowns")
 //=> "SEND IN THE CLOWNS!"
 ```
 
@@ -31,18 +31,18 @@ In our definition of `compose`, the `g` will run before the `f`, creating a righ
 
 ```js
 var shout = function(x){
-  return exclaim(toUpperCase(x));
-};
+  return exclaim(toUpperCase(x))
+}
 ```
 
 Instead of inside to outside, we run right to left, which I suppose is a step in the left direction[^boo]. Let's look at an example where sequence matters:
 
 ```js
-var head = function(x) { return x[0]; };
-var reverse = reduce(function(acc, x){ return [x].concat(acc); }, []);
-var last = compose(head, reverse);
+var head = function(x) { return x[0]; }
+var reverse = reduce(function(acc, x){ return [x].concat(acc); }, [])
+var last = compose(head, reverse)
 
-last(['jumpkick', 'roundhouse', 'uppercut']);
+last(['jumpkick', 'roundhouse', 'uppercut'])
 //=> 'uppercut'
 ```
 
@@ -50,32 +50,32 @@ last(['jumpkick', 'roundhouse', 'uppercut']);
 
 ```js
 // associativity
-var associative = compose(f, compose(g, h)) == compose(compose(f, g), h);
+var associative = compose(f, compose(g, h)) == compose(compose(f, g), h)
 // true
 ```
 
 Composition is associative, meaning it doesn't matter how you group two of them. So, should we choose to uppercase the string, we can write:
 
 ```js
-compose(toUpperCase, compose(head, reverse));
+compose(toUpperCase, compose(head, reverse))
 
 // or
-compose(compose(toUpperCase, head), reverse);
+compose(compose(toUpperCase, head), reverse)
 ```
 
 Since it doesn't matter how we group our calls to `compose`, the result will be the same. That allows use to write a variadic compose and use it as follows:
 
 ```js
 // previously we'd have to write two composes, but since it's associative, we can give compose as many fn's as we like and let it decide how to group them.
-var lastUpper = compose(toUpperCase, head, reverse);
+var lastUpper = compose(toUpperCase, head, reverse)
 
-lastUpper(['jumpkick', 'roundhouse', 'uppercut']);
+lastUpper(['jumpkick', 'roundhouse', 'uppercut'])
 //=> 'UPPERCUT'
 
 
 var loudLastUpper = compose(exclaim, toUpperCase, head, reverse)
 
-loudLastUpper(['jumpkick', 'roundhouse', 'uppercut']);
+loudLastUpper(['jumpkick', 'roundhouse', 'uppercut'])
 //=> 'UPPERCUT!'
 ```
 
@@ -84,16 +84,16 @@ Applying the associative property gives us this flexibility and peace of mind th
 One pleasant benefit of associativity is that any group of functions can be extracted and bundled together in their very own composition. Let's play with refactoring our previous example:
 
 ```js
-var loudLastUpper = compose(exclaim, toUpperCase, head, reverse);
+var loudLastUpper = compose(exclaim, toUpperCase, head, reverse)
 
 // or
-var last = compose(head, reverse);
-var loudLastUpper = compose(exclaim, toUpperCase, last);
+var last = compose(head, reverse)
+var loudLastUpper = compose(exclaim, toUpperCase, last)
 
 // or
-var last = compose(head, reverse);
-var angry = compose(exclaim, toUpperCase);
-var loudLastUpper = compose(angry, last);
+var last = compose(head, reverse)
+var angry = compose(exclaim, toUpperCase)
+var loudLastUpper = compose(angry, last)
 
 // more variations...
 ```
@@ -107,11 +107,11 @@ Pointfree style means never having to say your data. Excuse me. It means functio
 ```js
 //not pointfree because we mention the data: word
 var snakeCase = function (word) {
-  return word.toLowerCase().replace(/\s+/ig, '_');
-};
+  return word.toLowerCase().replace(/\s+/ig, '_')
+}
 
 //pointfree
-var snakeCase = compose(replace(/\s+/ig, '_'), toLowerCase);
+var snakeCase = compose(replace(/\s+/ig, '_'), toLowerCase)
 ```
 
 See how we partially applied `replace`? What we're doing is piping our data through each function of 1 argument. Currying allows us to prepare each function to just take its data, operate on it, and pass it along. Something else to notice is how we don't need the data to construct our function in the pointfree version, whereas in the pointful one, we must have our `word` available before anything else.
@@ -121,13 +121,13 @@ Let's look at another example.
 ```js
 //not pointfree because we mention the data: name
 var initials = function (name) {
-  return name.split(' ').map(compose(toUpperCase, head)).join('. ');
-};
+  return name.split(' ').map(compose(toUpperCase, head)).join('. ')
+}
 
 //pointfree
-var initials = compose(join('. '), map(compose(toUpperCase, head)), split(' '));
+var initials = compose(join('. '), map(compose(toUpperCase, head)), split(' '))
 
-initials("hunter stockton thompson");
+initials("hunter stockton thompson")
 // 'H. S. T'
 ```
 
@@ -138,16 +138,16 @@ A common mistake is to compose something like `map`, a function of two arguments
 
 ```js
 //wrong - we end up giving angry an array and we partially applied map with god knows what.
-var latin = compose(map, angry, reverse);
+var latin = compose(map, angry, reverse)
 
-latin(["frog", "eyes"]);
+latin(["frog", "eyes"])
 // error
 
 
 // right - each function expects 1 argument.
-var latin = compose(map(angry), reverse);
+var latin = compose(map(angry), reverse)
 
-latin(["frog", "eyes"]);
+latin(["frog", "eyes"])
 // ["SEYE!", "GORF!"])
 ```
 
@@ -155,29 +155,29 @@ If you are having trouble debugging a composition, we can use this helpful, but 
 
 ```js
 var trace = curry(function(tag, x){
-  console.log(tag, x);
-  return x;
-});
+  console.log(tag, x)
+  return x
+})
 
-var dasherize = compose(join('-'), replace(/\s{2,}/ig, ' '), split(' '));
+var dasherize = compose(join('-'), replace(/\s{2,}/ig, ' '), split(' '))
 
-dasherize('the world is a vampire');
+dasherize('the world is a vampire')
 // TypeError: Object the,world,is,a,vampire has no method 'replace'
 ```
 
 Something is wrong here, let's `trace`
 
 ```js
-var dasherize = compose(join('-'), replace(/\s{2,}/ig, ' '), trace("after split"), split(' '));
+var dasherize = compose(join('-'), replace(/\s{2,}/ig, ' '), trace("after split"), split(' '))
 // after split [ 'the', 'world', 'is', 'a', 'vampire' ]
 ```
 
 Ah! We need to `map` this `replace` since it's working on an array.
 
 ```js
-var dasherize = compose(join('-'), map(replace(/\s{2,}/ig, ' ')), split(' '));
+var dasherize = compose(join('-'), map(replace(/\s{2,}/ig, ' ')), split(' '))
 
-dasherize('the world is a vampire');
+dasherize('the world is a vampire')
 
 // 'the-world-is-a-vampire'
 ```
@@ -222,16 +222,16 @@ Here is an image demonstrating composition:
 Here is a concrete example in code:
 
 ```js
-var g = function(x){ return x.length; };
-var f = function(x){ return x === 4; };
-var isFourLetterWord = compose(f, g);
+var g = function(x){ return x.length; }
+var f = function(x){ return x === 4; }
+var isFourLetterWord = compose(f, g)
 ```
 
 **A distinguished morphism called identity**
 Let's introduce a useful function called `id`. This function simply takes some input and spits it back at you. Take a look:
 
 ```js
-var id = function(x){ return x; };
+var id = function(x){ return x; }
 ```
 
 You might ask yourself "What in the bloody hell is that useful for?". We'll make extensive use of this function in the following chapters, but for now think of it as a function that can stand in for our value - a function masquerading as every day data.
@@ -240,7 +240,7 @@ You might ask yourself "What in the bloody hell is that useful for?". We'll make
 
 ```js
 // identity
-var identity = compose(id, f) == compose(f, id) == f;
+var identity = compose(id, f) == compose(f, id) == f
 // true
 ```
 
@@ -263,9 +263,9 @@ We are now at a point where it would serve us well to see some of this in practi
 ## Exercises
 
 ```js
-require('../../support');
-var _ = require('ramda');
-var accounting = require('accounting');
+require('../../support')
+var _ = require('ramda')
+var accounting = require('accounting')
   
 // Example Data
 var CARS = [
@@ -275,20 +275,20 @@ var CARS = [
     {name: "Audi R8", horsepower: 525, dollar_value: 114200, in_stock: false},
     {name: "Aston Martin One-77", horsepower: 750, dollar_value: 1850000, in_stock: true},
     {name: "Pagani Huayra", horsepower: 700, dollar_value: 1300000, in_stock: false}
-  ];
+  ]
 
 // Exercise 1:
 // ============
 // use _.compose() to rewrite the function below. Hint: _.prop() is curried.
 var isLastInStock = function(cars) {
-  var last_car = _.last(cars);
-  return _.prop('in_stock', last_car);
-};
+  var last_car = _.last(cars)
+  return _.prop('in_stock', last_car)
+}
 
 // Exercise 2:
 // ============
 // use _.compose(), _.prop() and _.head() to retrieve the name of the first car
-var nameOfFirstCar = undefined;
+var nameOfFirstCar = undefined
 
 
 // Exercise 3:
@@ -297,9 +297,9 @@ var nameOfFirstCar = undefined;
 var _average = function(xs) { return reduce(add, 0, xs) / xs.length; }; // <- leave be
 
 var averageDollarValue = function(cars) {
-  var dollar_values = map(function(c) { return c.dollar_value; }, cars);
-  return _average(dollar_values);
-};
+  var dollar_values = map(function(c) { return c.dollar_value; }, cars)
+  return _average(dollar_values)
+}
 
 
 // Exercise 4:
@@ -308,7 +308,7 @@ var averageDollarValue = function(cars) {
 
 var _underscore = replace(/\W+/g, '_'); //<-- leave this alone and use to sanitize
 
-var sanitizeNames = undefined;
+var sanitizeNames = undefined
 
 
 // Bonus 1:
@@ -316,11 +316,11 @@ var sanitizeNames = undefined;
 // Refactor availablePrices with compose.
 
 var availablePrices = function(cars) {
-  var available_cars = _.filter(_.prop('in_stock'), cars);
+  var available_cars = _.filter(_.prop('in_stock'), cars)
   return available_cars.map(function(x){
-    return accounting.formatMoney(x.dollar_value);
-  }).join(', ');
-};
+    return accounting.formatMoney(x.dollar_value)
+  }).join(', ')
+}
 
 
 // Bonus 2:
@@ -328,10 +328,10 @@ var availablePrices = function(cars) {
 // Refactor to pointfree. Hint: you can use _.flip()
 
 var fastestCar = function(cars) {
-  var sorted = _.sortBy(function(car){ return car.horsepower }, cars);
-  var fastest = _.last(sorted);
-  return fastest.name + ' is the fastest';
-};
+  var sorted = _.sortBy(function(car){ return car.horsepower }, cars)
+  var fastest = _.last(sorted)
+  return fastest.name + ' is the fastest'
+}
 ```
 
 [lodash-website]: https://lodash.com/

--- a/ch6.md
+++ b/ch6.md
@@ -12,14 +12,14 @@ For some folks, myself included, it's hard to grasp the concept of declarative c
 
 ```js
 // imperative
-var makes = [];
+var makes = []
 for (i = 0; i < cars.length; i++) { 
-  makes.push(cars[i].make);
+  makes.push(cars[i].make)
 }
 
 
 // declarative
-var makes = cars.map(function(car){ return car.make; });
+var makes = cars.map(function(car){ return car.make; })
 ```
 
 The imperative loop must first instantiate the array. The interpreter must evaluate this statement before moving on. Then it directly iterates through the list of cars, manually increasing a counter and showing its bits and pieces to us in a vulgar display of explicit iteration.
@@ -35,12 +35,12 @@ Here is another example.
 ```js
 // imperative
 var authenticate = function(form) {
-  var user = toUser(form);
-  return logIn(user);
-};
+  var user = toUser(form)
+  return logIn(user)
+}
 
 // declarative
-var authenticate = compose(logIn, toUser);
+var authenticate = compose(logIn, toUser)
 ```
 
 Though there's nothing necessarily wrong with the imperative version, there is still an encoded step-by-step evaluation baked in. The `compose` expression simply states a fact: Authentication is the composition of `toUser` and `logIn`. Again, this leaves wiggle room for support code changes and results in our application code being a high level specification.
@@ -71,7 +71,7 @@ requirejs.config({
     ramda: 'https://cdnjs.cloudflare.com/ajax/libs/ramda/0.13.0/ramda.min',
     jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min'
   }
-});
+})
 
 require([
     'ramda',
@@ -79,11 +79,11 @@ require([
   ],
   function (_, $) {
     var trace = _.curry(function(tag, x) {
-      console.log(tag, x);
-      return x;
-    });
+      console.log(tag, x)
+      return x
+    })
     // app goes here
-  });
+  })
 ```
 
 We're pulling in [ramda](http://ramdajs.com) instead of lodash or some other utility library. It includes `compose`, `curry`, and more. I've used requirejs, which may seem like overkill, but we'll be using it throughout the book and consistency is key. Also, I've started us off with our nice `trace` function for easy debugging.
@@ -100,13 +100,13 @@ There are 2 impure actions mentioned above. Do you see them? Those bits about ge
 ```js
 var Impure = {
   getJSON: _.curry(function(callback, url) {
-    $.getJSON(url, callback);
+    $.getJSON(url, callback)
   }),
 
   setHtml: _.curry(function(sel, html) {
-    $(sel).html(html);
+    $(sel).html(html)
   })
-};
+}
 ```
 
 Here we've simply wrapped jQuery's methods to be curried and we've swapped the arguments to a more favorable position. I've namespaced them with `Impure` so we know these are dangerous functions. In a future example, we will make these two functions pure.
@@ -115,8 +115,8 @@ Next we must construct a url to pass to our `Impure.getJSON` function.
 
 ```js
 var url = function (term) {
-  return 'http://api.flickr.com/services/feeds/photos_public.gne?tags=' + term + '&format=json&jsoncallback=?';
-};
+  return 'http://api.flickr.com/services/feeds/photos_public.gne?tags=' + term + '&format=json&jsoncallback=?'
+}
 ```
 
 There are fancy and overly complex ways of writing `url` pointfree using monoids[^we'll learn about these later] or combinators. We've chosen to stick with a readable version and assemble this string in the normal pointful fashion.
@@ -124,9 +124,9 @@ There are fancy and overly complex ways of writing `url` pointfree using monoids
 Let's write an app function that makes the call and places the contents on the screen.
 
 ```js
-var app = _.compose(Impure.getJSON(trace("response")), url);
+var app = _.compose(Impure.getJSON(trace("response")), url)
 
-app("cats");
+app("cats")
 ```
 
 This calls our `url` function, then passes the string to our `getJSON` function, which has been partially applied with `trace`. Loading the app will show the response from the api call in the console.
@@ -139,23 +139,23 @@ Anyhow, to get at these nested properties we can use a nice universal getter fun
 
 ```js
 var prop = _.curry(function(property, object){
-  return object[property];
-});
+  return object[property]
+})
 ```
 
 It's quite dull actually. We just use `[]` syntax to access a property on whatever object. Let's use this to get at our srcs.
 
 ```js
-var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-var srcs = _.compose(_.map(mediaUrl), _.prop('items'));
+var srcs = _.compose(_.map(mediaUrl), _.prop('items'))
 ```
 
 Once we gather the `items`, we must `map` over them to extract each media url. This results in a nice array of srcs. Let's hook this up to our app and print them on the screen.
 
 ```js
-var renderImages = _.compose(Impure.setHtml("body"), srcs);
-var app = _.compose(Impure.getJSON(renderImages), url);
+var renderImages = _.compose(Impure.setHtml("body"), srcs)
+var app = _.compose(Impure.getJSON(renderImages), url)
 ```
 
 All we've done is make a new composition that will call our `srcs` and set the body html with them. We've replaced the `trace` call with `renderImages` now that we have something to render besides raw json. This will crudely display our srcs directly in the body.
@@ -164,16 +164,16 @@ Our final step is to turn these srcs into bonafide images. In a bigger applicati
 
 ```js
 var img = function (url) {
-  return $('<img />', { src: url });
-};
+  return $('<img />', { src: url })
+}
 ```
 
 jQuery's `html()` method will accept an array of tags. We only have to transform our srcs into images and send them along to `setHtml`.
 
 ```js
-var images = _.compose(_.map(img), srcs);
-var renderImages = _.compose(Impure.setHtml("body"), images);
-var app = _.compose(Impure.getJSON(renderImages), url);
+var images = _.compose(_.map(img), srcs)
+var renderImages = _.compose(Impure.setHtml("body"), images)
+var app = _.compose(Impure.getJSON(renderImages), url)
 ```
 
 And we're done!
@@ -187,7 +187,7 @@ requirejs.config({
     ramda: 'https://cdnjs.cloudflare.com/ajax/libs/ramda/0.13.0/ramda.min',
     jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min'
   }
-});
+})
 
 require([
     'ramda',
@@ -199,41 +199,41 @@ require([
 
     var Impure = {
       getJSON: _.curry(function(callback, url) {
-        $.getJSON(url, callback);
+        $.getJSON(url, callback)
       }),
 
       setHtml: _.curry(function(sel, html) {
-        $(sel).html(html);
+        $(sel).html(html)
       })
-    };
+    }
 
     var img = function (url) {
-      return $('<img />', { src: url });
-    };
+      return $('<img />', { src: url })
+    }
 
     var trace = _.curry(function(tag, x) {
-      console.log(tag, x);
-      return x;
-    });
+      console.log(tag, x)
+      return x
+    })
 
     ////////////////////////////////////////////
 
     var url = function (t) {
-      return 'http://api.flickr.com/services/feeds/photos_public.gne?tags=' + t + '&format=json&jsoncallback=?';
-    };
+      return 'http://api.flickr.com/services/feeds/photos_public.gne?tags=' + t + '&format=json&jsoncallback=?'
+    }
 
-    var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+    var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-    var srcs = _.compose(_.map(mediaUrl), _.prop('items'));
+    var srcs = _.compose(_.map(mediaUrl), _.prop('items'))
 
-    var images = _.compose(_.map(img), srcs);
+    var images = _.compose(_.map(img), srcs)
 
-    var renderImages = _.compose(Impure.setHtml("body"), images);
+    var renderImages = _.compose(Impure.setHtml("body"), images)
 
-    var app = _.compose(Impure.getJSON(renderImages), url);
+    var app = _.compose(Impure.getJSON(renderImages), url)
 
-    app("cats");
-  });
+    app("cats")
+  })
 ```
 
 Now look at that. A beautifully declarative specification of what things are, not how they come to be. We now view each line as an equation with properties that hold. We can use these properties to reason about our application and refactor.
@@ -245,45 +245,45 @@ There is an optimization available - we map over each item to turn it into a med
 
 ```js
 // map's composition law
-var law = compose(map(f), map(g)) == map(compose(f, g));
+var law = compose(map(f), map(g)) == map(compose(f, g))
 ```
 
 We can use this property to optimize our code. Let's have a principled refactor.
 
 ```js
 // original code
-var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-var srcs = _.compose(_.map(mediaUrl), _.prop('items'));
+var srcs = _.compose(_.map(mediaUrl), _.prop('items'))
 
-var images = _.compose(_.map(img), srcs);
+var images = _.compose(_.map(img), srcs)
 
 ```
 
 Let's line up our maps. We can inline the call to `srcs` in `images` thanks to equational reasoning and purity.
 
 ```js
-var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-var images = _.compose(_.map(img), _.map(mediaUrl), _.prop('items'));
+var images = _.compose(_.map(img), _.map(mediaUrl), _.prop('items'))
 ```
 
 Now that we've lined up our `map`'s we can apply the composition law.
 
 ```js
-var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-var images = _.compose(_.map(_.compose(img, mediaUrl)), _.prop('items'));
+var images = _.compose(_.map(_.compose(img, mediaUrl)), _.prop('items'))
 ```
 
 Now the bugger will only loop once while turning each item into an img. Let's just make it a little more readable by extracting the function out.
 
 ```js
-var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-var mediaToImg = _.compose(img, mediaUrl);
+var mediaToImg = _.compose(img, mediaUrl)
 
-var images = _.compose(_.map(mediaToImg), _.prop('items'));
+var images = _.compose(_.map(mediaToImg), _.prop('items'))
 ```
 
 ## In Summary

--- a/ch7.md
+++ b/ch7.md
@@ -18,7 +18,7 @@ From the dusty pages of math books, across the vast sea of white papers, amongst
 //  capitalize :: String -> String
 var capitalize = function(s){ return toUpperCase(head(s)) + toLowerCase(tail(s)); }
 
-capitalize("smurf");
+capitalize("smurf")
 //=> "Smurf"
 ```
 
@@ -31,23 +31,23 @@ Let's look some more function signatures:
 ```js
 //  strLength :: String -> Number
 var strLength = function(s){
-  return s.length;
+  return s.length
 }
 
 //  join :: String -> [String] -> String
 var join = curry(function(what, xs){
-  return xs.join(what);
-});
+  return xs.join(what)
+})
 
 //  match :: Regex -> String -> [String]
 var match = curry(function(reg, s){
-  return s.match(reg);
-});
+  return s.match(reg)
+})
 
 //  replace :: Regex -> String -> String -> String
 var replace = curry(function(reg, sub, s){
-  return s.replace(reg, sub);
-});
+  return s.replace(reg, sub)
+})
 ```
 
 `strLength` is the same idea as before: we take a `String` and return you a `Number`.
@@ -59,8 +59,8 @@ For `match` we are free to group the signature like so:
 ```js
 //  match :: Regex -> (String -> [String])
 var match = curry(function(reg, s){
-  return s.match(reg);
-});
+  return s.match(reg)
+})
 ```
 
 Ah yes, grouping the last part in parenthesis reveals more information. Now it is seen a function that takes a `Regex` and returns us a function from `String` to `[String]`. Because of currying, this is indeed the case: give it a `Regex` and we get a function back waiting for its `String` argument. Of course, we don't have to think of it this way, but it is good to understand why the last type is the one returned.
@@ -69,7 +69,7 @@ Ah yes, grouping the last part in parenthesis reveals more information. Now it i
 //  match :: Regex -> (String -> [String])
 
 //  onHoliday :: String -> [String]
-var onHoliday = match(/holiday/ig);
+var onHoliday = match(/holiday/ig)
 ```
 
 Each argument pops one type off the front of the signature. `onHoliday` is `match` that already has a `Regex`.
@@ -77,8 +77,8 @@ Each argument pops one type off the front of the signature. `onHoliday` is `matc
 ```js
 //  replace :: Regex -> (String -> (String -> String))
 var replace = curry(function(reg, sub, s){
-  return s.replace(reg, sub);
-});
+  return s.replace(reg, sub)
+})
 ```
 
 As you can see with the full parenthesis on `replace`, the extra notation can get a little noisy and redundant so we simply omit them. We can give all the arguments at once if we choose so it's easier to just think of it as: `replace` takes a `Regex`, a `String`, another `String` and returns you a `String`.
@@ -92,8 +92,8 @@ var id = function(x){ return x; }
 
 //  map :: (a -> b) -> [a] -> [b]
 var map = curry(function(f, xs){
-  return xs.map(f);
-});
+  return xs.map(f)
+})
 ```
 
 The `id` function takes any old type `a` and returns something of the same type `a`. We're able to use variables in types just like in code. Variable names like `a` and `b` are convention, but they are arbitrary and can be replaced with whatever name you'd like. If they are the same variable, they have to be the same type. That's an important rule so let's reiterate: `a -> b` can be any type `a` to any type `b`, but `a -> a` means it has to be the same type. For example, `id` may be `String -> String` or `Number -> Number`, but not `String -> Bool`.
@@ -112,13 +112,13 @@ var head = function(xs){ return xs[0]; }
 
 //  filter :: (a -> Bool) -> [a] -> [a]
 var filter = curry(function(f, xs){
-  return xs.filter(f);
-});
+  return xs.filter(f)
+})
 
 //  reduce :: (b -> a -> b) -> b -> [a] -> b
 var reduce = curry(function(f, x, xs){
-  return xs.reduce(f, x);
-});
+  return xs.reduce(f, x)
+})
 ```
 
 `reduce` is perhaps, the most expressive of all. It's a tricky one, however, so don't feel inadequate should you struggle with it.
@@ -149,10 +149,10 @@ Besides deducing implementation possibilities, this sort of reasoning gains us *
 
 ```js
 // head :: [a] -> a
-compose(f, head) == compose(head, map(f));
+compose(f, head) == compose(head, map(f))
 
 // filter :: (a -> Bool) -> [a] -> [a]
-compose(map(f), filter(compose(p, f))) == compose(filter(p), map(f));
+compose(map(f), filter(compose(p, f))) == compose(filter(p), map(f))
 ```
 
 

--- a/ch8.md
+++ b/ch8.md
@@ -10,10 +10,10 @@ First we will create a container. This container must hold any type of value; a 
 
 ```js
 var Container = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
-Container.of = function(x) { return new Container(x); };
+Container.of = function(x) { return new Container(x); }
 ```
 
 Here is our first container. We've thoughtfully named it `Container`. We will use `Container.of` as a constructor which saves us from having to write that god awful `new` keyword all over the place. There's more to the `of` function than meets the eye, but for now, think of it as the proper way to place values into our container.
@@ -89,35 +89,35 @@ What reason could we possibly have for bottling up a value and using `map` to ge
 
 ```js
 var Maybe = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
 Maybe.of = function(x) {
-  return new Maybe(x);
+  return new Maybe(x)
 }
 
 Maybe.prototype.isNothing = function() {
-  return (this.__value === null || this.__value === undefined);
+  return (this.__value === null || this.__value === undefined)
 }
 
 Maybe.prototype.map = function(f) {
-  return this.isNothing() ? Maybe.of(null) : Maybe.of(f(this.__value));
+  return this.isNothing() ? Maybe.of(null) : Maybe.of(f(this.__value))
 }
 ```
 
 Now, `Maybe` looks a lot like `Container` with one minor change: it will first check to see if it has a value before calling the supplied function. This has the effect of side stepping those pesky nulls as we `map`.
 
 ```js
-Maybe.of("Malkovich Malkovich").map(match(/a/ig));
+Maybe.of("Malkovich Malkovich").map(match(/a/ig))
 //=> Maybe(['a', 'a'])
 
-Maybe.of(null).map(match(/a/ig));
+Maybe.of(null).map(match(/a/ig))
 //=> Maybe(null)
 
-Maybe.of({name: "Boris"}).map(_.prop("age")).map(add(10));
+Maybe.of({name: "Boris"}).map(_.prop("age")).map(add(10))
 //=> Maybe(null)
 
-Maybe.of({name: "Dinah", age: 14}).map(_.prop("age")).map(add(10));
+Maybe.of({name: "Dinah", age: 14}).map(_.prop("age")).map(add(10))
 //=> Maybe(24)
 ```
 
@@ -128,8 +128,8 @@ This dot syntax is perfectly fine and functional, but for reasons mentioned in P
 ```js
 //  map :: Functor f => (a -> b) -> f a -> f b
 var map = curry(function(f, any_functor_at_all) {
-  return any_functor_at_all.map(f);
-});
+  return any_functor_at_all.map(f)
+})
 ```
 
 This is delightful as we can carry on with composition per usual and `map` will work as expected. This is the case with ramda's `map` as well. We'll use dot notation when it's instructive and the pointfree version when it's convenient. Did you notice that? I've sneakily introduced extra notation into our type signature. The `Functor f =>` tells us that `f` must be a Functor. Not that difficult, but I felt I should mention it.
@@ -141,15 +141,15 @@ In the wild, we'll typically see `Maybe` used in functions which might fail to r
 ```js
 //  safeHead :: [a] -> Maybe(a)
 var safeHead = function(xs) {
-  return Maybe.of(xs[0]);
-};
+  return Maybe.of(xs[0])
+}
 
-var streetName = compose(map(_.prop('street')), safeHead, _.prop('addresses'));
+var streetName = compose(map(_.prop('street')), safeHead, _.prop('addresses'))
 
-streetName({addresses: []});
+streetName({addresses: []})
 // Maybe(null)
 
-streetName({addresses: [{street: "Shady Ln.", number: 4201}]});
+streetName({addresses: [{street: "Shady Ln.", number: 4201}]})
 // Maybe("Shady Ln.")
 ```
 
@@ -162,20 +162,20 @@ Sometimes a function might return a `Maybe(null)` explicitly to signal failure. 
 //  withdraw :: Number -> Account -> Maybe(Account)
 var withdraw = curry(function(amount, account) {
   return account.balance >= amount ? Maybe.of({balance: account.balance - amount}) : Maybe.of(null); 
-});
+})
 
 //  finishTransaction :: Account -> String
 var finishTransaction = compose(remainingBalance, updateLedger); //<-- omitted for simplicity
 
 //  getTwenty :: Account -> Maybe(String)
-var getTwenty = compose(map(finishTransaction), withdraw(20));
+var getTwenty = compose(map(finishTransaction), withdraw(20))
 
 
 
-getTwenty({ balance: 200.00});
+getTwenty({ balance: 200.00})
 // Maybe("Your balance is $180.00")
 
-getTwenty({ balance: 10.00});
+getTwenty({ balance: 10.00})
 // Maybe(null)
 ```
 
@@ -192,17 +192,17 @@ There is, however, an escape hatch. If we would rather return a custom value and
 ```js
 //  maybe :: b -> (a -> b) -> Maybe a -> b
 var maybe = curry(function(x, f, m) {
-  return m.isNothing() ? x : f(m.__value);
-});
+  return m.isNothing() ? x : f(m.__value)
+})
 
 //  getTwenty :: Account -> String
-var getTwenty = compose(maybe("You're broke!", finishTransaction), withdraw(20));
+var getTwenty = compose(maybe("You're broke!", finishTransaction), withdraw(20))
 
 
-getTwenty({ balance: 200.00});
+getTwenty({ balance: 200.00})
 // "Your balance is $180.00"
 
-getTwenty({ balance: 10.00});
+getTwenty({ balance: 10.00})
 // "You're broke!"
 ```
 
@@ -221,43 +221,43 @@ It may come as a shock, but `throw/catch` is not very pure. When an error is thr
 
 ```js
 var Left = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
 Left.of = function(x) {
-  return new Left(x);
+  return new Left(x)
 }
 
 Left.prototype.map = function(f) {
-  return this;
+  return this
 }
 
 var Right = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
 Right.of = function(x) {
-  return new Right(x);
+  return new Right(x)
 }
 
 Right.prototype.map = function(f) {
-  return Right.of(f(this.__value));
+  return Right.of(f(this.__value))
 }
 ```
 
 `Left` and `Right` are two subclasses of an abstract type we call `Either`. I've skipped the ceremony of creating the `Either` superclass as we won't ever use it, but it's good to be aware. Now then, there's nothing new here besides the two types. Let's see how they act:
 
 ```js
-Right.of("rain").map(function(str){ return "b"+str; });
+Right.of("rain").map(function(str){ return "b"+str; })
 // Right("brain")
 
-Left.of("rain").map(function(str){ return "b"+str; });
+Left.of("rain").map(function(str){ return "b"+str; })
 // Left("rain")
 
-Right.of({host: 'localhost', port: 80}).map(_.prop('host'));
+Right.of({host: 'localhost', port: 80}).map(_.prop('host'))
 // Right('localhost')
 
-Left.of("rolls eyes...").map(_.prop("host"));
+Left.of("rolls eyes...").map(_.prop("host"))
 // Left('rolls eyes...')
 ```
 
@@ -266,19 +266,19 @@ Left.of("rolls eyes...").map(_.prop("host"));
 Suppose we have a function that might not succeed. How about we calculate an age from a birth date. We could use `Maybe(null)` to signal failure and branch our program, however, that doesn't tell us much. Perhaps, we'd like to know why it failed. Let's write this using `Either`.
 
 ```js
-var moment = require('moment');
+var moment = require('moment')
 
 //  getAge :: Date -> User -> Either(String, Number)
 var getAge = curry(function(now, user) {
-  var birthdate = moment(user.birthdate, 'YYYY-MM-DD');
-  if(!birthdate.isValid()) return Left.of("Birth date could not be parsed");
-  return Right.of(now.diff(birthdate, 'years'));
-});
+  var birthdate = moment(user.birthdate, 'YYYY-MM-DD')
+  if(!birthdate.isValid()) return Left.of("Birth date could not be parsed")
+  return Right.of(now.diff(birthdate, 'years'))
+})
 
-getAge(moment(), {birthdate: '2005-12-12'});
+getAge(moment(), {birthdate: '2005-12-12'})
 // Right(9)
 
-getAge(moment(), {birthdate: '20010704'});
+getAge(moment(), {birthdate: '20010704'})
 // Left("Birth date could not be parsed")
 ```
 
@@ -286,16 +286,16 @@ Now, just like `Maybe(null)`, we are short circuiting our app when we return a `
 
 ```js
 //  fortune :: Number -> String
-var fortune  = compose(concat("If you survive, you will be "), add(1));
+var fortune  = compose(concat("If you survive, you will be "), add(1))
 
 //  zoltar :: User -> Either(String, _)
-var zoltar = compose(map(console.log), map(fortune), getAge(moment()));
+var zoltar = compose(map(console.log), map(fortune), getAge(moment()))
 
-zoltar({birthdate: '2005-12-12'});
+zoltar({birthdate: '2005-12-12'})
 // "If you survive, you will be 10"
 // Right(undefined)
 
-zoltar({birthdate: 'balloons!'});
+zoltar({birthdate: 'balloons!'})
 // Left("Birth date could not be parsed")
 ```
 
@@ -315,19 +315,19 @@ Just like with `Maybe`, we have little `either`, which behaves similarly, but ta
 //  either :: (a -> c) -> (b -> c) -> Either a b -> c
 var either = curry(function(f, g, e) {
   switch(e.constructor) {
-    case Left: return f(e.__value);
-    case Right: return g(e.__value);
+    case Left: return f(e.__value)
+    case Right: return g(e.__value)
   }
-});
+})
 
 //  zoltar :: User -> _
-var zoltar = compose(console.log, either(id, fortune), getAge(moment()));
+var zoltar = compose(console.log, either(id, fortune), getAge(moment()))
 
-zoltar({birthdate: '2005-12-12'});
+zoltar({birthdate: '2005-12-12'})
 // "If you survive, you will be 10"
 // undefined
 
-zoltar({birthdate: 'balloons!'});
+zoltar({birthdate: 'balloons!'})
 // "Birth date could not be parsed"
 // undefined
 ```
@@ -344,7 +344,7 @@ In our chapter about purity we saw a peculiar example of a pure function. This f
 //  getFromStorage :: String -> (_ -> String)
 var getFromStorage = function(key) {
   return function() {
-    return localStorage[key];
+    return localStorage[key]
   }
 }
 ```
@@ -355,17 +355,17 @@ Except, this isn't particularly useful now is it. Like a collectable action figu
 
 ```js
 var IO = function(f) {
-  this.__value = f;
+  this.__value = f
 }
 
 IO.of = function(x) {
   return new IO(function() {
-    return x;
-  });
+    return x
+  })
 }
 
 IO.prototype.map = function(f) {
-  return new IO(_.compose(f, this.__value));
+  return new IO(_.compose(f, this.__value))
 }
 ```
 
@@ -375,21 +375,21 @@ Let's see it in use:
 
 ```js
 //  io_window_ :: IO Window
-var io_window = new IO(function(){ return window; });
+var io_window = new IO(function(){ return window; })
 
-io_window.map(function(win){ return win.innerWidth });
+io_window.map(function(win){ return win.innerWidth })
 // IO(1430)
 
-io_window.map(_.prop('location')).map(_.prop('href')).map(split('/'));
+io_window.map(_.prop('location')).map(_.prop('href')).map(split('/'))
 // IO(["http:", "", "localhost:8000", "blog", "posts"])
 
 
 //  $ :: String -> IO [DOM]
 var $ = function(selector) {
-  return new IO(function(){ return document.querySelectorAll(selector); });
+  return new IO(function(){ return document.querySelectorAll(selector); })
 }
 
-$('#myDiv').map(head).map(function(div){ return div.innerHTML; });
+$('#myDiv').map(head).map(function(div){ return div.innerHTML; })
 // IO('I am some inner html')
 ```
 
@@ -404,23 +404,23 @@ Now, we've caged the beast, but we'll still have to set it free at some point. M
 ////// Our pure library: lib/params.js ///////
 
 //  url :: IO String
-var url = new IO(function() { return window.location.href; });
+var url = new IO(function() { return window.location.href; })
 
 //  toPairs =  String -> [[String]]
-var toPairs = compose(map(split('=')), split('&'));
+var toPairs = compose(map(split('=')), split('&'))
 
 //  params :: String -> [[String]]
-var params = compose(toPairs, last, split('?'));
+var params = compose(toPairs, last, split('?'))
 
 //  findParam :: String -> IO Maybe [String]
 var findParam = function(key) {
-  return map(compose(Maybe.of, filter(compose(eq(key), head)), params), url);
-};
+  return map(compose(Maybe.of, filter(compose(eq(key), head)), params), url)
+}
 
 ////// Impure calling code: main.js ///////
 
 // run it by calling __value()!
-findParam("searchTerm").__value();
+findParam("searchTerm").__value()
 // Maybe(['searchTerm', 'wafflehouse'])
 ```
 
@@ -430,11 +430,11 @@ There's something that's been bothering me and we should rectify it immediately:
 
 ```js
 var IO = function(f) {
-  this.unsafePerformIO = f;
+  this.unsafePerformIO = f
 }
 
 IO.prototype.map = function(f) {
-  return new IO(_.compose(f, this.unsafePerformIO));
+  return new IO(_.compose(f, this.unsafePerformIO))
 }
 ```
 
@@ -453,18 +453,18 @@ The internals are a bit too complicated to spill out all over the page here so w
 // Node readfile example:
 //=======================
 
-var fs = require('fs');
+var fs = require('fs')
 
 //  readFile :: String -> Task(Error, JSON)
 var readFile = function(filename) {
   return new Task(function(reject, result) {
     fs.readFile(filename, 'utf-8', function(err, data) {
-      err ? reject(err) : result(data);
-    });
-  });
-};
+      err ? reject(err) : result(data)
+    })
+  })
+}
 
-readFile("metamorphosis").map(split('\n')).map(head);
+readFile("metamorphosis").map(split('\n')).map(head)
 // Task("One morning, as Gregor Samsa was waking up from anxious dreams, he discovered that
 // in bed he had been changed into a monstrous verminous bug.")
 
@@ -475,15 +475,15 @@ readFile("metamorphosis").map(split('\n')).map(head);
 //  getJSON :: String -> {} -> Task(Error, JSON)
 var getJSON = curry(function(url, params) {
   return new Task(function(reject, result) {
-    $.getJSON(url, params, result).fail(reject);
-  });
-});
+    $.getJSON(url, params, result).fail(reject)
+  })
+})
 
-getJSON('/video', {id: 10}).map(_.prop('title'));
+getJSON('/video', {id: 10}).map(_.prop('title'))
 // Task("Family Matters ep 15")
 
 // We can put normal, non futuristic values inside as well
-Task.of(3).map(function(three){ return three + 1 });
+Task.of(3).map(function(three){ return three + 1 })
 // Task(4)
 ```
 
@@ -501,13 +501,13 @@ To run our `Task`, we must call the method `fork`. This works like `unsafePerfor
 // blogTemplate :: String
 
 //  blogPage :: Posts -> HTML
-var blogPage = Handlebars.compile(blogTemplate);
+var blogPage = Handlebars.compile(blogTemplate)
 
 //  renderPage :: Posts -> HTML
-var renderPage = compose(blogPage, sortBy('date'));
+var renderPage = compose(blogPage, sortBy('date'))
 
 //  blog :: Params -> Task(Error, HTML)
-var blog = compose(map(renderPage), getJSON('/posts'));
+var blog = compose(map(renderPage), getJSON('/posts'))
 
 
 // Impure calling code
@@ -515,9 +515,9 @@ var blog = compose(map(renderPage), getJSON('/posts'));
 blog({}).fork(
   function(error){ $("#error").html(error.message); },
   function(page){ $("#main").html(page); }
-);
+)
 
-$('#spinner').show();
+$('#spinner').show()
 ```
 
 Upon calling `fork`, the `Task` hurries off to find some posts and render the page. Meanwhile, we show a spinner since `fork` does not wait for a response. Finally, we will either display an error or render the page onto the screen depending if the `getJSON` call succeeded or not.
@@ -540,19 +540,19 @@ Even with `Task`, our `IO` and `Either` functors are not out of a job. Bear with
 var dbUrl = function(c) {
   return (c.uname && c.pass && c.host && c.db)
     ? Right.of("db:pg://"+c.uname+":"+c.pass+"@"+c.host+"5432/"+c.db)
-    : Left.of(Error("Invalid config!"));
+    : Left.of(Error("Invalid config!"))
 }
 
 //  connectDb :: Config -> Either(Error, IO(DbConnection))
-var connectDb = compose(map(Postgres.connect), dbUrl);
+var connectDb = compose(map(Postgres.connect), dbUrl)
 
 //  getConfig :: Filename -> Task(Error, Either(Error, IO(DbConnection)))
-var getConfig = compose(map(compose(connectDB, JSON.parse)), readFile);
+var getConfig = compose(map(compose(connectDB, JSON.parse)), readFile)
 
 
 // Impure calling code
 //=====================
-getConfig("db.json").fork(logErr("couldn't read file"), either(console.log, map(runQuery)));
+getConfig("db.json").fork(logErr("couldn't read file"), either(console.log, map(runQuery)))
 ```
 
 In this example, we still make use of `Either` and `IO` from within the success branch of `readFile`. `Task` takes care of the impurities of reading a file asynchronously, but we still deal with validating the config with `Either` and wrangling the db connection with `IO`. So you see, we're still in business for all things synchronous.
@@ -568,35 +568,35 @@ As mentioned before, functors come from category theory and satisfy a few laws. 
 
 ```js
 // identity
-map(id) === id;
+map(id) === id
 
 // composition
-compose(map(f), map(g)) === map(compose(f, g));
+compose(map(f), map(g)) === map(compose(f, g))
 ```
 
 The *identity* law is simple, but important. These laws are runnable bits of code so we can try them on our own functors to validate their legitimacy.
 
 ```js
-var idLaw1 = map(id);
-var idLaw2 = id;
+var idLaw1 = map(id)
+var idLaw2 = id
 
-idLaw1(Container.of(2));
+idLaw1(Container.of(2))
 //=> Container(2)
 
-idLaw2(Container.of(2));
+idLaw2(Container.of(2))
 //=> Container(2)
 ```
 
 You see, they are equal. Next let's look at composition.
 
 ```js
-var compLaw1 = compose(map(concat(" world")), map(concat(" cruel")));
-var compLaw2 = map(compose(concat(" world"), concat(" cruel")));
+var compLaw1 = compose(map(concat(" world")), map(concat(" cruel")))
+var compLaw2 = map(compose(concat(" world"), concat(" cruel")))
 
-compLaw1(Container.of("Goodbye"));
+compLaw1(Container.of("Goodbye"))
 //=> Container('Goodbye cruel world')
 
-compLaw2(Container.of("Goodbye"));
+compLaw2(Container.of("Goodbye"))
 //=> Container('Goodbye cruel world')
 ```
 
@@ -616,16 +616,16 @@ In addition to visualizing the mapped morphism from one category to another unde
 
 ```js
 //  topRoute :: String -> Maybe(String)
-var topRoute = compose(Maybe.of, reverse);
+var topRoute = compose(Maybe.of, reverse)
 
 //  bottomRoute :: String -> Maybe(String)
-var bottomRoute = compose(map(reverse), Maybe.of);
+var bottomRoute = compose(map(reverse), Maybe.of)
 
 
-topRoute("hi");
+topRoute("hi")
 // Maybe("ih")
 
-bottomRoute("hi");
+bottomRoute("hi")
 // Maybe("ih")
 ```
 
@@ -638,9 +638,9 @@ We can instantly see and refactor code based on properties held by all functors.
 Functors can stack:
 
 ```js
-var nested = Task.of([Right.of("pillows"), Left.of("no sleep for you")]);
+var nested = Task.of([Right.of("pillows"), Left.of("no sleep for you")])
 
-map(map(map(toUpperCase)), nested);
+map(map(map(toUpperCase)), nested)
 // Task([Right("PILLOWS"), Left("no sleep for you")])
 ```
 
@@ -648,21 +648,21 @@ What we have here with `nested` is a future array of elements that might be erro
 
 ```js
 var Compose = function(f_g_x){
-  this.getCompose = f_g_x;
+  this.getCompose = f_g_x
 }
  
 Compose.prototype.map = function(f){
-  return new Compose(map(map(f), this.getCompose));
+  return new Compose(map(map(f), this.getCompose))
 }
 
 var tmd = Task.of(Maybe.of("Rock over London"))
 
-var ctmd = new Compose(tmd);
+var ctmd = new Compose(tmd)
 
-map(concat(", rock on, Chicago"), ctmd);
+map(concat(", rock on, Chicago"), ctmd)
 // Compose(Task(Maybe("Rock over London, rock on, Chicago")))
 
-ctmd.getCompose;
+ctmd.getCompose
 // Task(Maybe("Rock over London, rock on, Chicago"))
 ```
 
@@ -680,9 +680,9 @@ What about calling a function with multiple functor arguments? How about working
 ## Exercises
 
 ```js
-require('../../support');
-var Task = require('data.task');
-var _ = require('ramda');
+require('../../support')
+var Task = require('data.task')
+var _ = require('ramda')
 
 // Exercise 1
 // ==========
@@ -695,7 +695,7 @@ var ex1 = undefined
 //Exercise 2
 // ==========
 // Use _.head to get the first element of the list
-var xs = Identity.of(['do', 'ray', 'me', 'fa', 'so', 'la', 'ti', 'do']);
+var xs = Identity.of(['do', 'ray', 'me', 'fa', 'so', 'la', 'ti', 'do'])
 
 var ex2 = undefined
 
@@ -704,9 +704,9 @@ var ex2 = undefined
 // Exercise 3
 // ==========
 // Use safeProp and _.head to find the first initial of the user
-var safeProp = _.curry(function (x, o) { return Maybe.of(o[x]); });
+var safeProp = _.curry(function (x, o) { return Maybe.of(o[x]); })
 
-var user = { id: 2, name: "Albert" };
+var user = { id: 2, name: "Albert" }
 
 var ex3 = undefined
 
@@ -717,7 +717,7 @@ var ex3 = undefined
 
 var ex4 = function (n) {
   if (n) { return parseInt(n); }
-};
+}
 
 var ex4 = undefined
 
@@ -733,7 +733,7 @@ var getPost = function (i) {
     setTimeout(function(){
       res({id: i, title: 'Love them futures'})  
     }, 300)
-  });
+  })
 }
 
 var ex5 = undefined
@@ -770,9 +770,9 @@ var ex7 = function(x) {
 
 var save = function(x){
   return new IO(function(){
-    console.log("SAVED USER!");
-    return x + '-saved';
-  });
+    console.log("SAVED USER!")
+    return x + '-saved'
+  })
 }
 
 var ex8 = undefined

--- a/code/part1_demo/flickr.js
+++ b/code/part1_demo/flickr.js
@@ -3,7 +3,7 @@ requirejs.config({
     ramda: 'https://cdnjs.cloudflare.com/ajax/libs/ramda/0.13.0/ramda.min',
     jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min'
   }
-});
+})
 
 require([
     'ramda',
@@ -14,8 +14,8 @@ require([
     // Utils
     //
     var img = function (url) {
-       return $('<img />', { src: url });
-    };
+       return $('<img />', { src: url })
+    }
 
     var Impure = {
       getJSON: _.curry(function(callback, url) {
@@ -28,8 +28,8 @@ require([
     }
 
     var trace = _.curry(function(tag, x) {
-        console.log(tag, x);
-        return x;
+        console.log(tag, x)
+        return x
     })
 
     ////////////////////////////////////////////
@@ -37,14 +37,14 @@ require([
 
     //  url :: String -> URL
     var url = function (t) {
-      return 'http://api.flickr.com/services/feeds/photos_public.gne?tags=' + t + '&format=json&jsoncallback=?';
-    };
+      return 'http://api.flickr.com/services/feeds/photos_public.gne?tags=' + t + '&format=json&jsoncallback=?'
+    }
 
-    var mediaUrl = _.compose(_.prop('m'), _.prop('media'));
+    var mediaUrl = _.compose(_.prop('m'), _.prop('media'))
 
-    var srcs = _.compose(_.map(mediaUrl), _.prop('items'));
+    var srcs = _.compose(_.map(mediaUrl), _.prop('items'))
 
-    var images = _.compose(_.map(img), srcs);
+    var images = _.compose(_.map(img), srcs)
 
 
     ////////////////////////////////////////////
@@ -54,4 +54,4 @@ require([
     var app = _.compose(Impure.getJSON(renderImages), url)
 
     app("cats")
-  });
+  })

--- a/code/part2_exercises/support.js
+++ b/code/part2_exercises/support.js
@@ -1,10 +1,10 @@
-require('../part1_exercises/support');
-var _ = require('ramda');
-var Task = require('data.task');
-var curry = _.curry;
+require('../part1_exercises/support')
+var _ = require('ramda')
+var Task = require('data.task')
+var curry = _.curry
 
 inspect = function(x) {
-  return (x && x.inspect) ? x.inspect() : x;
+  return (x && x.inspect) ? x.inspect() : x
 }
 
 toUpperCase = function(x) {
@@ -13,128 +13,128 @@ toUpperCase = function(x) {
 
 // Identity
 Identity = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
-Identity.of = function(x) { return new Identity(x); };
+Identity.of = function(x) { return new Identity(x); }
 
 Identity.prototype.map = function(f) {
   return Identity.of(f(this.__value))
 }
 
 Identity.prototype.inspect = function() {
-  return 'Identity('+inspect(this.__value)+')';
+  return 'Identity('+inspect(this.__value)+')'
 }
 
 // Maybe
 Maybe = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
 Maybe.of = function(x) {
-  return new Maybe(x);
+  return new Maybe(x)
 }
 
 Maybe.prototype.isNothing = function(f) {
-  return (this.__value === null || this.__value === undefined);
+  return (this.__value === null || this.__value === undefined)
 }
 
 Maybe.prototype.map = function(f) {
-  return this.isNothing() ? this : Maybe.of(f(this.__value));
+  return this.isNothing() ? this : Maybe.of(f(this.__value))
 }
 
 Maybe.prototype.join = function() {
-  return this.__value;
+  return this.__value
 }
 
 Maybe.prototype.inspect = function() {
-  return 'Maybe('+inspect(this.__value)+')';
+  return 'Maybe('+inspect(this.__value)+')'
 }
 
 
 // Either
-Either = function() {};
+Either = function() {}
 Either.of = function(x) {
-  return new Right(x);
+  return new Right(x)
 }
 
 Left = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
 Left.of = function(x) {
-  return new Left(x);
+  return new Left(x)
 }
 
 Left.prototype.map = function(f) { return this; }
 Left.prototype.join = function() { return this; } 
 Left.prototype.chain = function() { return this; }
 Left.prototype.inspect = function() {
-  return 'Left('+inspect(this.__value)+')';
+  return 'Left('+inspect(this.__value)+')'
 }
 
 
 Right = function(x) {
-  this.__value = x;
+  this.__value = x
 }
 
 Right.of = function(x) {
-  return new Right(x);
+  return new Right(x)
 }
 
 Right.prototype.map = function(f) {
-  return Right.of(f(this.__value));
+  return Right.of(f(this.__value))
 }
 
 Right.prototype.join = function() {
-  return this.__value;
+  return this.__value
 }
 
 Right.prototype.chain = function(f) {
-  return f(this.__value);
+  return f(this.__value)
 }
 
 Right.prototype.inspect = function() {
-  return 'Right('+inspect(this.__value)+')';
+  return 'Right('+inspect(this.__value)+')'
 }
 
 // IO
 IO = function(f) {
-  this.unsafePerformIO = f;
+  this.unsafePerformIO = f
 }
 
 IO.of = function(x) {
   return new IO(function() {
-    return x;
-  });
+    return x
+  })
 }
 
 IO.prototype.map = function(f) {
-  return new IO(_.compose(f, this.unsafePerformIO));
+  return new IO(_.compose(f, this.unsafePerformIO))
 }
 
 IO.prototype.join = function() {
-  return this.unsafePerformIO();
+  return this.unsafePerformIO()
 }
 
 IO.prototype.inspect = function() {
-  return 'IO('+inspect(this.__value)+')';
+  return 'IO('+inspect(this.__value)+')'
 }
 
 unsafePerformIO = function(x) { return x.unsafePerformIO(); }
 
 either = curry(function(f, g, e) {
   switch(e.constructor) {
-    case Left: return f(e.__value);
-    case Right: return g(e.__value);
+    case Left: return f(e.__value)
+    case Right: return g(e.__value)
   }
-});
+})
 
 // overwriting join from pt 1
-join = function(m){ return m.join(); };
+join = function(m){ return m.join(); }
 
 chain = curry(function(f, m){
   return m.map(f).join(); // or compose(join, map(f))(m)
-});
+})
 
 Task.prototype.join = function(){ return this.chain(_.identity); }


### PR DESCRIPTION
Semicolons are really not necessary in well-formated JS, it’s just a syntactic noise. You can read a comprehensive explanation in [Standard](https://github.com/feross/standard) (code-style) [here](https://github.com/feross/standard/blob/master/RULES.md#automatic-semicolon-insertion-asi).

This PR is a direct reaction to #92. Now you can simply choose if you want to consistently add, or remove unnecessary semicolons.

Don’t hesitate to just close this PR without any reaction if you don’t want to remove semicolons, I’m perfectly fine with that! It’s naturally up to you how you choose to format code in your book. However, @chicoxyzzy is right that you should be consistent, if possible.

I’m looking forward to the Part 3 of your wonderful book! :smile_cat: