### PR TITLE
fixed typo in functor exercises

### DIFF
--- a/code/part2_exercises/exercises/functors/functor_exercises.js
+++ b/code/part2_exercises/exercises/functors/functor_exercises.js
@@ -85,7 +85,7 @@ var ex7 = function(x) {
 
 // Exercise 8
 // ==========
-// Use ex7 above and Either as a functor to save the user if they are valid or return the error message string. Remember either's two arguments must return the same type.
+// Use ex7 above and either as a functor to save the user if they are valid or return the error message string. Remember either's two arguments must return the same type.
 
 var save = function(x) {
   return new IO(function() {


### PR DESCRIPTION
Exercise 8 in part2_exercises/functors, wrongly referred to using the `Either` method, whereas it should be the `either` method.