### PR TITLE
Typo fix

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -552,7 +552,7 @@ var dbUrl = function(c) {
 var connectDb = compose(map(Postgres.connect), dbUrl);
 
 //  getConfig :: Filename -> Task Error (Either Error (IO DbConnection))
-var getConfig = compose(map(compose(connectDB, JSON.parse)), readFile);
+var getConfig = compose(map(compose(connectDb, JSON.parse)), readFile);
 
 
 // Impure calling code


### PR DESCRIPTION
`connectDb` was declared with lowercase b but used with uppercase B