### PR TITLE
Fix typo in chapter 10, exercise 3

### DIFF
--- a/code/part2_exercises/exercises/applicative/applicative_exercises_spec.js
+++ b/code/part2_exercises/exercises/applicative/applicative_exercises_spec.js
@@ -17,7 +17,7 @@ describe("Applicative Exercises", function(){
 
   it('Exercise 3', function(done){
     E.ex3.fork(console.log, function (html) {
-      assert.equal("<div>Love them tasks</div><li>This book should be illegal</li><li>Monads are like space burritos</li>", html);
+      assert.equal("<div>Love them futures</div><li>This book should be illegal</li><li>Monads are like space burritos</li>", html);
       done();
     });
   });


### PR DESCRIPTION
The test helper function and the assertion inside the spec file mismatch
the post title. The assertion has been edited to fix this issue.

This fixes
https://github.com/MostlyAdequate/mostly-adequate-guide/issues/163