### PR TITLE
Typos fixes

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -431,7 +431,7 @@ var ex3 = undefined;
 
 // Exercise 4
 // ==========
-// Use validateEmail, addToMailingList, and emailBlast to implmeent ex4's type
+// Use validateEmail, addToMailingList, and emailBlast to implement ex4's type
 // signature.
 
 //  addToMailingList :: Email -> IO([Email])

--- a/code/part2_exercises/answers/monads/monad_exercises.js
+++ b/code/part2_exercises/answers/monads/monad_exercises.js
@@ -4,7 +4,7 @@ var _ = require('ramda');
 
 // Exercise 1
 // ==========
-// Use safeProp and map/join or chain to safetly get the street name when given a user
+// Use safeProp and map/join or chain to safely get the street name when given a user
 
 var safeProp = _.curry(function (x, o) { return Maybe.of(o[x]); });
 var user = {
@@ -65,7 +65,7 @@ var ex3 = _.compose(chain(_.compose(getComments, _.prop('id'))), getPost);
 
 // Exercise 4
 // ==========
-// Use validateEmail and addToMailingList to implmeent ex4's type signature. It should 
+// Use validateEmail and addToMailingList to implement ex4's type signature. It should 
 
 //  addToMailingList :: Email -> IO([Email])
 var addToMailingList = (function(list){

--- a/code/part2_exercises/exercises/monads/monad_exercises.js
+++ b/code/part2_exercises/exercises/monads/monad_exercises.js
@@ -4,7 +4,7 @@ var _ = require('ramda');
 
 // Exercise 1
 // ==========
-// Use safeProp and map/join or chain to safetly get the street name when given a user
+// Use safeProp and map/join or chain to safely get the street name when given a user
 
 var safeProp = _.curry(function (x, o) { return Maybe.of(o[x]); });
 var user = {
@@ -65,7 +65,7 @@ var ex3 = undefined;
 
 // Exercise 4
 // ==========
-// Use validateEmail, addToMailingList and emailBlast to implmeent ex4's type signature.
+// Use validateEmail, addToMailingList and emailBlast to implement ex4's type signature.
 // It should safely add a new subscriber to the list, then email everyone with this happy news.
 
 //  addToMailingList :: Email -> IO [Email]

--- a/code/part2_exercises/exercises/monads/monad_exercises.js
+++ b/code/part2_exercises/exercises/monads/monad_exercises.js
@@ -78,7 +78,7 @@ var addToMailingList = (function(list){
   }
 })([]);
 
-//       emailBlast :: [Email] -> IO String
+//  emailBlast :: [Email] -> IO String
 function emailBlast(list) {
   return new IO(function(){
     return 'emailed: ' + list.join(','); // for testing w/o mocks


### PR DESCRIPTION
misspelled “safely”
misspelled “implement”