### PR TITLE
Simplify visual perception of findParam

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -419,7 +419,16 @@ var params = compose(toPairs, last, split('?'));
 
 //  findParam :: String -> IO Maybe [String]
 var findParam = function(key) {
-  return map(compose(Maybe.of, filter(compose(eq(key), head)), params), url);
+  return map(
+    compose(
+      Maybe.of, 
+      filter(
+        compose(eq(key), head)
+      ), 
+      params
+    ), 
+    url
+  );
 };
 
 ////// Impure calling code: main.js ///////


### PR DESCRIPTION
If there are more than 3 bracket pairs on one line in functional coding style, visual decoding becomes much more challenging than the code itself. This is just a suggestion.