### PR TITLE
Suggestion: Expressions over Statements

### DIFF
--- a/ch3.md
+++ b/ch3.md
@@ -243,11 +243,7 @@ var isSameTeam = function(player1, player2) {
 };
 
 var punch = function(player, target) {
-  if (isSameTeam(player, target)) {
-    return target;
-  } else {
-    return decrementHP(target);
-  }
+  return isSameTeam(player, target)? target : decrementHP(target)
 };
 
 var jobe = Immutable.Map({name:"Jobe", hp:20, team: "red"});
@@ -263,11 +259,7 @@ First we'll inline the function `isSameTeam`.
 
 ```js
 var punch = function(player, target) {
-  if (player.get("team") === target.get("team")) {
-    return target;
-  } else {
-    return decrementHP(target);
-  }
+  return player.get("team") === target.get("team")? target : decrementHP(target)
 };
 ```
 
@@ -275,11 +267,7 @@ Since our data is immutable, we can simply replace the teams with their actual v
 
 ```js
 var punch = function(player, target) {
-  if ("red" === "green") {
-    return target;
-  } else {
-    return decrementHP(target);
-  }
+  return "red" === "green"? target : decrementHP(target)
 };
 ```
 


### PR DESCRIPTION
Shouldn't we promote expressions over statements when following a more functional style i Javascript?

It might be too soon I was just thinking about how it would look in newer versions of JS.

```js
const
  {Map} = require("immutable") // Not sure this line would work

, decrementHP =
    (player) => player.set("hp", player.get("hp")-1)

, isSameTeam =
    (player1, player2) => player1.get("team") === player2.get("team")

, punch =
    (player, target) =>
      isSameTeam(player, target) ? target : decrementHP(target)

, jobe = Map({name:"Jobe", hp:20, team: "red"});
, michael = Map({name:"Michael", hp:20, team: "green"});

punch(jobe, michael);
//=> Immutable.Map({name:"Michael", hp:19, team: "green"})
```

Expressions only and no `return` 

```js
// Example 1 -- Standard
if(pred) {
  return foo;
} else {
 return bar;
}

// Example 2 -- If one exist the function early why have the extra noise from the `else` branch.
if(pred) {  return foo; } 
return bar;

// Example 3 -- why have the extra noise by 2x`return` when an expression could be used.
return pred? foo : bar
```
Examples:  2 `or` 3 > 1 

I might be silly but I think its similar to `2a + 2b = 2(a+b)` e.g., might be more clear in a Haskell example
```hs
-- Okay
if pred
  then SomeDataConstructor (argA, argB)
  else SomeDataConstructor (argC, argD)

-- Better
SomeDataConstructor
  (if pred
    then (argA, argB)
    else (argC, argD))
```