### PR TITLE
fix ch4 typos

### DIFF
--- a/ch4.md
+++ b/ch4.md
@@ -26,7 +26,7 @@ addTen(2);
 
 Here we've made a function `add` that takes one argument and returns a function. By calling it, the returned function remembers the first argument from then on via the closure. Calling it with both arguments all at once is a bit of a pain, however, so we can use a special helper function called `curry` to make defining and calling functions like this easier.
 
-Let's setup a few curried functions for our enjoyment.
+Let's set up a few curried functions for our enjoyment.
 
 ```js
 var curry = require('lodash.curry');
@@ -103,7 +103,7 @@ var getChildren = function(x) {
 var allTheChildren = map(getChildren);
 ```
 
-Giving a function fewer arguments than it expects is typically called *partial application*. Partially applying a function can remove a lot of boiler plate code. Consider what the above `allTheChildren` function would be with the uncurried `map` from lodash(note the arguments are in a different order):
+Giving a function fewer arguments than it expects is typically called *partial application*. Partially applying a function can remove a lot of boiler plate code. Consider what the above `allTheChildren` function would be with the uncurried `map` from lodash (note the arguments are in a different order):
 
 ```js
 var allTheChildren = function(elements) {


### PR DESCRIPTION
Adds a couple of missing spaces:
*setup* -> *set up*
*lodash(note* -> *lodash (note*
