### PR TITLE
Use this instead of referencing by name

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -13,7 +13,7 @@ var Container = function(x) {
   this.__value = x;
 }
 
-Container.of = function(x) { return new Container(x); };
+Container.of = function(x) { return new this(x); };
 ```
 
 Here is our first container. We've thoughtfully named it `Container`. We will use `Container.of` as a constructor which saves us from having to write that god awful `new` keyword all over the place. There's more to the `of` function than meets the eye, but for now, think of it as the proper way to place values into our container.


### PR DESCRIPTION
It might feel more "natural" to use `this` keyword in this instance. Since it would make refactoring easier and allow us to reuse `of` function for example.

```js
var of = function(x) { return new this(x); };

var Container = function(x) {
  this.__value = x;
}
Container.of = of;

var Jar = function(x) {
  this.__value = x;
}

Jar.of = of;
```