### PR TITLE
ch4: require curry from lodash package

### DIFF
--- a/ch4.md
+++ b/ch4.md
@@ -29,7 +29,7 @@ Here we've made a function `add` that takes one argument and returns a function.
 Let's set up a few curried functions for our enjoyment.
 
 ```js
-var curry = require('lodash.curry');
+var curry = require('lodash/curry');
 
 var match = curry(function(what, str) {
   return str.match(what);


### PR DESCRIPTION
This patch replaces `require('lodash.curry')` with `require('lodash/curry')` in code examples.

See https://github.com/MostlyAdequate/mostly-adequate-guide/pull/249#issuecomment-188357391.