### PR TITLE
ch10: add missing liftA2 in one of the examples

### DIFF
--- a/ch10.md
+++ b/ch10.md
@@ -253,7 +253,7 @@ To demonstrate:
 ```js
   var tOfM = compose(Task.of, Maybe.of);
 
-  liftA2(_.concat, tOfM('Rainy Days and Mondays'), tOfM(' always get me down'));
+  liftA2(liftA2(_.concat), tOfM('Rainy Days and Mondays'), tOfM(' always get me down'));
   // Task(Maybe('Rainy Days and Mondays always get me down'))
 ```
 


### PR DESCRIPTION
The first example in the `Laws` section of chapter 10 is not correct:

```js
require('./support');
var Task = require('data.task');
var _ = require('ramda');


var tOfM = _.compose(Task.of, Maybe.of);

liftA2(_.concat, tOfM('Rainy Days and Mondays'), tOfM(' always get me down'))
  .fork(console.log, console.log);
```

```
$ node example
            throw new TypeError('can\'t concat ' + typeof set1);
            ^

TypeError: can't concat object
```

Instead, `_.concat` needs to be lifted into Maybe type:

```js
var tOfM = _.compose(Task.of, Maybe.of);

liftA2(liftA2(_.concat), tOfM('Rainy Days and Mondays'), tOfM(' always get me down'))
  .fork(console.log, console.log);
```

```
$ node example
Maybe(Rainy Days and Mondays always get me down)
```

This is by the way a nice example of `liftA2` being partially applied (as discussed earlier in this chapter).