### PR TITLE
ch9: fix HTTP upload examples

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -329,7 +329,7 @@ Let's read a file, then upload it directly afterward:
 
 ```js
 // readFile :: Filename -> Either String (Task Error String)
-// httpPost :: String -> Task Error JSON
+// httpPost :: String -> String -> Task Error JSON
 
 //  upload :: String -> Either String (Task Error JSON)
 var upload = compose(map(chain(httpPost('/uploads'))), readFile);
@@ -349,7 +349,7 @@ var upload = function(filename, callback) {
   } else {
     readFile(filename, function(err, contents) {
       if (err) throw err;
-      httpPost(contents, function(err, json) {
+      httpPost('/uploads', contents, function(err, json) {
         if (err) throw err;
         callback(json);
       });


### PR DESCRIPTION
First example in the section “Power Trip” in chapter 9 doesn't typecheck and needs a change in on of the signatures:

```diff
 // readFile :: Filename -> Either String (Task Error String)
-// httpPost :: String -> Task Error JSON
+// httpPost :: String -> String -> Task Error JSON
 
 //  upload :: String -> Either String (Task Error JSON)
 var upload = compose(map(chain(httpPost('/uploads'))), readFile);
```

Second example (“imperative way”) is not an equivalent to the above and should be changed like this:

```diff
 //  upload :: String -> (String -> a) -> Void
 var upload = function(filename, callback) {
   if (!filename) {
     throw "You need a filename!";
   } else {
     readFile(filename, function(err, contents) {
       if (err) throw err;
-      httpPost(contents, function(err, json) {
+      httpPost('/uploads', contents, function(err, json) {
         if (err) throw err;
         callback(json);
       });
     });
   }
 };
```