### PR TITLE
Add toArray function

### DIFF
--- a/code/part1_exercises/support.js
+++ b/code/part1_exercises/support.js
@@ -1,8 +1,9 @@
 //var curry = require('ramda').curry;
-//
-//
-//
-//
+
+function toArray(x) {
+  return x != null ? Array.from(x) : x;
+}
+
 function inspect(x) {
   return (typeof x === 'function') ? inspectFn(x) : inspectArgs(x);
 }


### PR DESCRIPTION
Line 42 of `part1_exercises/support.js` calls toArray, which is not defined, so I wrote it. It uses the ES6 static `from` method on `Array`, which is supported in Node >= 4.

Oddly, this was causing me trouble when running tests in part 2.