### PR TITLE
Change invalid date format to make unparseable

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -320,7 +320,7 @@ getAge(moment(), {
 // Right(9)
 
 getAge(moment(), {
-  birthdate: '20010704',
+  birthdate: 'July 4, 2001',
 });
 // Left('Birth date could not be parsed')
 ```


### PR DESCRIPTION
As of moment 2.16.0, the command `moment("20010704", "YYYY-MM-DD")` **is** successfully parsed. You can achieve the desired error by changing the date string to something very malformed like "July 4, 2001".