### PR TITLE
Fix Left prototype map function

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -261,7 +261,7 @@ Left.of = function(x) {
 };
 
 Left.prototype.map = function(f) {
-  return this;
+  return Left.of(f(this.__value));
 };
 
 var Right = function(x) {


### PR DESCRIPTION
It looks like the map function wasn't filled out all the way, and so hopefully this is the implementation the author was intending to write, which it seems to be due to the way Left.of('rain').map is used on line 288.

Thanks!