### PR TITLE
Simple typo fix: "amendable" -> "amenable"

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -21,7 +21,7 @@ map(tldr, files)
 // [Task('hail the monarchy'), Task('smash the patriarchy')]
 ```
 
-Here we read a bunch of files and end up with a useless array of tasks. How might we fork each one of these? It would be most agreeable if we could switch the types around to have `Task Error [String]` instead of `[Task Error String]`. That way, we'd have one future value holding all the results, which is much more amendable to our async needs than several future values arriving at their leisure.
+Here we read a bunch of files and end up with a useless array of tasks. How might we fork each one of these? It would be most agreeable if we could switch the types around to have `Task Error [String]` instead of `[Task Error String]`. That way, we'd have one future value holding all the results, which is much more amenable to our async needs than several future values arriving at their leisure.
 
 Here's one last example of a sticky situation:
 


### PR DESCRIPTION
"Amendable" might apply here(?), but I assume you were going for "amenable".