### PR TITLE
Bug: With sepia the links are not highlighted

### DIFF
--- a/styles/website.css
+++ b/styles/website.css
@@ -1,0 +1,3 @@
+.book.color-theme-1 .book-body .page-wrapper .page-inner section.normal a {
+    color: initial;
+}


### PR DESCRIPTION
This is an old problem in GitBook as described in GitbookIO/gitbook#949.
I copied the workaround described there in https://github.com/GitbookIO/gitbook/issues/949#issuecomment-285365251