### PR TITLE
Update gitbook links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,28 +23,28 @@ That said, typed functional languages will, without a doubt, be the best place t
 
 ## Read it Online
 
-For a best reading experience, [read it online via Gitbook](https://drboolean.gitbooks.io/mostly-adequate-guide/content/). 
+For a best reading experience, [read it online via Gitbook](https://mostly-adequate.gitbooks.io/mostly-adequate-guide/).
 
-- Quick-access side-bar 
+- Quick-access side-bar
 - In-browser exercises
 - In-depth examples
 
 
 ## Download it
 
-* [Download PDF](https://www.gitbook.com/download/pdf/book/drboolean/mostly-adequate-guide)
-* [Download EPUB](https://www.gitbook.com/download/epub/book/drboolean/mostly-adequate-guide)
-* [Download Mobi (Kindle)](https://www.gitbook.com/download/mobi/book/drboolean/mostly-adequate-guide)
+* [Download PDF](https://www.gitbook.com/download/pdf/book/mostly-adequate/mostly-adequate-guide)
+* [Download EPUB](https://www.gitbook.com/download/epub/book/mostly-adequate/mostly-adequate-guide)
+* [Download Mobi (Kindle)](https://www.gitbook.com/download/mobi/book/mostly-adequate/mostly-adequate-guide)
 
 
 ## Do it yourself
 
 ```
-git clone https://github.com/DrBoolean/mostly-adequate-guide.git
+git clone https://github.com/MostlyAdequate/mostly-adequate-guide.git
 cd mostly-adequate-guide/
 npm install
 npm run setup
-gitbook pdf 
+gitbook pdf
 ```
 
 

--- a/ch04.md
+++ b/ch04.md
@@ -92,7 +92,7 @@ Let's acquire another essential tool called `compose`.
 #### Note About Exercises
 
 Throughout the book, you might encounter an 'Exercises' section like this one. Exercises can be
-done directly in-browser provided you're reading from [gitbook](https://drboolean.gitbooks.io/mostly-adequate-guide/in-summary) (recommended).
+done directly in-browser provided you're reading from [gitbook](https://mostly-adequate.gitbooks.io/mostly-adequate-guide) (recommended).
 
 Note that, for all exercises of the book, you always have a handful of helper functions
 available in the global scope. Hence, anything that is define in [Appendix A](./appendix_a.md),


### PR DESCRIPTION
If I understood it correctly, the gitbook now can be found at https://mostly-adequate.gitbooks.io/mostly-adequate-guide/.

The `in-summary` in one of the old links seemed to be a mistake since it did not lead to a correct page.