### PR TITLE
`inspect` function does not exist in `inspect method`

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -108,7 +108,7 @@ class Maybe {
   }
 
   inspect() {
-    return this.isNothing ? 'Nothing' : `Just(${inspect(this.$value)})`;
+    return this.isNothing ? 'Nothing' : `Just(${this.$value})`;
   }
 }
 ```
@@ -252,7 +252,7 @@ class Left extends Either {
   }
 
   inspect() {
-    return `Left(${inspect(this.$value)})`;
+    return `Left(${this.$value})`;
   }
 }
 
@@ -262,7 +262,7 @@ class Right extends Either {
   }
 
   inspect() {
-    return `Right(${inspect(this.$value)})`;
+    return `Right(${this.$value})`;
   }
 }
 
@@ -401,7 +401,7 @@ class IO {
   }
 
   inspect() {
-    return `IO(${inspect(this.$value)})`;
+    return `IO(${this.$value})`;
   }
 }
 ```


### PR DESCRIPTION
Corrected references to missing `inspect` function from within `inspect` method.