### PR TITLE
Uppercase Milner in ch07.md title

### DIFF
--- a/ch07.md
+++ b/ch07.md
@@ -1,4 +1,4 @@
-# Chapter 07: Hindley-milner and Me
+# Chapter 07: Hindley-Milner and Me
 
 ## What's Your Type?
 If you're new to the functional world, it won't be long before you find yourself knee deep in type signatures. Types are the meta language that enables people from all different backgrounds to communicate succinctly and effectively. For the most part, they're written with a system called "Hindley-Milner", which we'll be examining together in this chapter.


### PR DESCRIPTION
Milner is proper noun (surname) and seems to have been mistakenly lowercased.