### PR TITLE
Punctuation nitpicking ch04.md

### DIFF
--- a/ch04.md
+++ b/ch04.md
@@ -73,7 +73,7 @@ Giving a function fewer arguments than it expects is typically called *partial a
 const allTheChildren = elements => map(elements, getChildren);
 ```
 
-We typically don't define functions that work on arrays, because we can just call `map(getChildren)` inline. Same with `sort`, `filter`, and other higher order functions(Higher order function: A function that takes or returns a function).
+We typically don't define functions that work on arrays, because we can just call `map(getChildren)` inline. Same with `sort`, `filter`, and other higher order functions (a *higher order function* is a function that takes or returns a function).
 
 When we spoke about *pure functions*, we said they take 1 input to 1 output. Currying does exactly this: each single argument returns a new function expecting the remaining arguments. That, old sport, is 1 input to 1 output.
 


### PR DESCRIPTION
Fix punctuation and stylize _higher order function_ definition to match definition of other terms.