### PR TITLE
Type signature nitpicking ch08.md

### DIFF
--- a/appendix_c.md
+++ b/appendix_c.md
@@ -182,8 +182,8 @@ const toLowerCase = s => s.toLowerCase();
 ## toString
 
 ```js
-// toString :: Number -> String
-const toString = n => n.toString();
+// toString :: a -> String
+const toString = x => x.toString();
 ```
 
 ## toUpperCase

--- a/appendix_c.md
+++ b/appendix_c.md
@@ -179,6 +179,13 @@ const take = curry((n, xs) => xs.slice(0, n));
 const toLowerCase = s => s.toLowerCase();
 ```
 
+## toString
+
+```js
+// toString :: Number -> String
+const toString = n => n.toString();
+```
+
 ## toUpperCase
 
 ```js

--- a/ch08.md
+++ b/ch08.md
@@ -312,7 +312,7 @@ Now, just like `Nothing`, we are short-circuiting our app when we return a `Left
 
 ```js
 // fortune :: Number -> String
-const fortune = compose(concat('If you survive, you will be '), add(1));
+const fortune = compose(concat('If you survive, you will be '), toString, add(1));
 
 // zoltar :: User -> Either(String, _)
 const zoltar = compose(map(console.log), map(fortune), getAge(moment()));


### PR DESCRIPTION
I know we can play fast-and-loose with types in JS, but _technically_ `add` returns a number and `concat` expects a string (that is according to the docs in the appendix of this work and also in the Ramda docs, and the Ramda implementation of `concat` throws a `TypeError` when fed anything but a string). Ambiguous whether it should be explicitly noted `toString` is borrowed from Ramda, or if a simple version (`x => x.toString()`) should be added to appendix.