### PR TITLE
Correct the order of arguments for `concat`

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -689,15 +689,15 @@ class Compose {
   }
 }
 
-const tmd = Task.of(Maybe.of('Rock over London'));
+const tmd = Task.of(Maybe.of(', rock on, Chicago'));
 
 const ctmd = Compose.of(tmd);
 
-map(concat(', rock on, Chicago'), ctmd);
-// Compose(Task(Just(', rock on, ChicagoRock over London')))
+map(concat('Rock over London'), ctmd);
+// Compose(Task(Just('Rock over London, rock on, Chicago')))
 
 ctmd.getCompose;
-// Task(Just(', rock on, ChicagoRock over London'))
+// Task(Just('Rock over London, rock on, Chicago'))
 ```
 
 There, one `map`. Functor composition is associative and earlier, we defined `Container`, which is actually called the `Identity` functor. If we have identity and associative composition we have a category. This particular category has categories as objects and functors as morphisms, which is enough to make one's brain perspire. We won't delve too far into this, but it's nice to appreciate the architectural implications or even just the simple abstract beauty in the pattern.

--- a/ch08.md
+++ b/ch08.md
@@ -694,10 +694,10 @@ const tmd = Task.of(Maybe.of('Rock over London'));
 const ctmd = Compose.of(tmd);
 
 map(concat(', rock on, Chicago'), ctmd);
-// Compose(Task(Just('Rock over London, rock on, Chicago')))
+// Compose(Task(Just(', rock on, ChicagoRock over London')))
 
 ctmd.getCompose;
-// Task(Just('Rock over London, rock on, Chicago'))
+// Task(Just(', rock on, ChicagoRock over London'))
 ```
 
 There, one `map`. Functor composition is associative and earlier, we defined `Container`, which is actually called the `Identity` functor. If we have identity and associative composition we have a category. This particular category has categories as objects and functors as morphisms, which is enough to make one's brain perspire. We won't delve too far into this, but it's nice to appreciate the architectural implications or even just the simple abstract beauty in the pattern.


### PR DESCRIPTION
Corrected one of the last examples to match the `concat` examples earlier in the chapter, and as defined in appendix. Potentially confusing, I got hung up on this as it made it seem that `map` acts differently when operating on different functors.