### PR TITLE
Clarify order of evaluation

### DIFF
--- a/ch06.md
+++ b/ch06.md
@@ -44,7 +44,9 @@ const authenticate = compose(logIn, toUser);
 
 Though there's nothing necessarily wrong with the imperative version, there is still an encoded step-by-step evaluation baked in. The `compose` expression simply states a fact: Authentication is the composition of `toUser` and `logIn`. Again, this leaves wiggle room for support code changes and results in our application code being a high level specification.
 
-Because we are not encoding order of evaluation, declarative coding lends itself to parallel computing. This coupled with pure functions is why FP is a good option for the parallel future - we don't really need to do anything special to achieve parallel/concurrent systems.
+In the example above, the order of evaluation is specified (`toUser` must be called before `logIn`), but there are many scenarios where the order is not important, and this is easily specified with declarative coding (more on this later). 
+
+Because we don't have to encode the order of evaluation, declarative coding lends itself to parallel computing. This coupled with pure functions is why FP is a good option for the parallel future - we don't really need to do anything special to achieve parallel/concurrent systems.
 
 ## A Flickr of Functional Programming
 


### PR DESCRIPTION
The existing text states that "we are not encoding order of evalution", which does not make sense in the context of the code snippet above.

I have added some text to clarify the situation.

Another option would be to change the code snippet.