### PR TITLE
Ch 10: `toUpper` -> `toUpperCase` (to match docs)

### DIFF
--- a/ch10.md
+++ b/ch10.md
@@ -283,7 +283,7 @@ We're really just stuffing our normal functions and values into a container and 
 A quick example:
 
 ```js
-Either.of(toUpper).ap(Either.of('oreos')) === Either.of(toUpper('oreos'));
+Either.of(toUpperCase).ap(Either.of('oreos')) === Either.of(toUpperCase('oreos'));
 ```
 
 ### Interchange
@@ -314,7 +314,7 @@ A.of(compose).ap(u).ap(v).ap(w) === u.ap(v.ap(w));
 ```
 
 ```js
-const u = IO.of(toUpper);
+const u = IO.of(toUpperCase);
 const v = IO.of(concat('& beyond'));
 const w = IO.of('blood bath ');
 


### PR DESCRIPTION
The docs define `toUpperCase`, but not the alias `toUpper` used in Ch 10 (presumably borrowed from Ramda).