### PR TITLE
Minor typo: Tis' -> 'Tis

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -133,7 +133,7 @@ Instead of `map(map($))` we have `chain(traverse(IO.of, $))` which inverts our t
 
 ## No Law and Order
 
-Well now, before you get all judgemental and bang the backspace button like a gavel to retreat from the chapter, take a moment to recognize that these laws are useful code guarantees. Tis' my conjecture that the goal of most program architecture is an attempt to place useful restrictions on our code to narrow the possibilities, to guide us into the answers as designers and readers.
+Well now, before you get all judgemental and bang the backspace button like a gavel to retreat from the chapter, take a moment to recognize that these laws are useful code guarantees. 'Tis my conjecture that the goal of most program architecture is an attempt to place useful restrictions on our code to narrow the possibilities, to guide us into the answers as designers and readers.
 
 An interface without laws is merely indirection. Like any other mathematical structure, we must expose properties for our own sanity. This has a similar effect as encapsulation since it protects the data, enabling us to swap out the interface with another law abiding citizen.
 


### PR DESCRIPTION
Apostrophe should be at beginning, marking omission of the _"I"_