### PR TITLE
Replacing functions with ones shown in example

### DIFF
--- a/ch04.md
+++ b/ch04.md
@@ -58,7 +58,7 @@ been made available from the `exercises/support.js` module.
 
 ## More Than a Pun / Special Sauce
 
-Currying is useful for many things. We can make new functions just by giving our base functions some arguments as seen in `hasSpaces`, `findSpaces`, and `censored`.
+Currying is useful for many things. We can make new functions just by giving our base functions some arguments as seen in `hasLetterR`, `removeStringsWithoutRs`, and `censored`.
 
 We also have the ability to transform any function that works on single elements into a function that works on arrays simply by wrapping it with `map`:
 

--- a/ch04.md
+++ b/ch04.md
@@ -98,7 +98,7 @@ Throughout the book, you might encounter an 'Exercises' section like this one. E
 done directly in-browser provided you're reading from [gitbook](https://mostly-adequate.gitbooks.io/mostly-adequate-guide) (recommended).
 
 Note that, for all exercises of the book, you always have a handful of helper functions
-available in the global scope. Hence, anything that is define in [Appendix A](./appendix_a.md),
+available in the global scope. Hence, anything that is defined in [Appendix A](./appendix_a.md),
 [Appendix B](./appendix_b.md) and [Appendix C](./appendix_c.md) is available for you! And, as
 if it wasn't enough, some exercises will also define functions specific to the problem
 they present; as a matter of fact, consider them available as well.


### PR DESCRIPTION
There are no functions named `hasSpaces` or `findSpaces` in the book or the exercises, so I think it was meant to be `hasLetterR` and `removeStringsWithoutRs` instead.

Repo search results for [hasSpaces](https://github.com/MostlyAdequate/mostly-adequate-guide/search?utf8=%E2%9C%93&q=hasSpaces&type=) and [findSpaces](https://github.com/MostlyAdequate/mostly-adequate-guide/search?utf8=%E2%9C%93&q=findSpaces&type=).