### PR TITLE
Call reduce on array in compose example

### DIFF
--- a/ch05.md
+++ b/ch05.md
@@ -32,7 +32,7 @@ Instead of inside to outside, we run right to left, which I suppose is a step in
 
 ```js
 const head = x => x[0];
-const reverse = reduce((acc, x) => [x].concat(acc), []);
+const reverse = x => x.reduce((acc, x) => [x].concat(acc), []);
 const last = compose(head, reverse);
 
 last(['jumpkick', 'roundhouse', 'uppercut']); // 'uppercut'


### PR DESCRIPTION
I tried to run the following code in browser console:
```javascript
const reverse = reduce((acc, x) => [x].concat(acc), []);
```
 
It threw the following error:
```
Uncaught ReferenceError: reduce is not defined
    at <anonymous>:1:17
```

I think the method should be updated to
```javascript
const reverse = x => x.reduce((acc, x) => [x].concat(acc), []);
```
as `reduce` is a method on Array prototype ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce))