### PR TITLE
Fix spelling-variants on programming language names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a book on the functional paradigm in general. We'll use the world's most
 
     We have all the features we need to mimic a language like Scala or Haskell with the help of a tiny library or two. Object-oriented programming currently dominates the industry, but it's clearly awkward in JavaScript. It's akin to camping off of a highway or tap dancing in galoshes. We have to `bind` all over the place lest `this` change out from under us, we don't have classes (yet), we have various work arounds for the quirky behavior when the `new` keyword is forgotten, private members are only available via closures. To a lot of us, FP feels more natural anyways.
 
-That said, typed functional languages will, without a doubt, be the best place to code in the style presented by this book. JavaScript will be our means of learning a paradigm, where you apply it is up to you. Luckily, the interfaces are mathematical and, as such, ubiquitous. You'll find yourself at home with swiftz, scalaz, haskell, purescript, and other mathematically inclined environments.
+That said, typed functional languages will, without a doubt, be the best place to code in the style presented by this book. JavaScript will be our means of learning a paradigm, where you apply it is up to you. Luckily, the interfaces are mathematical and, as such, ubiquitous. You'll find yourself at home with Swiftz, Scalaz, Haskell, PureScript, and other mathematically inclined environments.
 
 
 ## Read it Online

--- a/ch05.md
+++ b/ch05.md
@@ -182,7 +182,7 @@ const dasherize = compose(
 dasherize('The world is a vampire'); // 'the-world-is-a-vampire'
 ```
 
-The `trace` function allows us to view the data at a certain point for debugging purposes. Languages like haskell and purescript have similar functions for ease of development.
+The `trace` function allows us to view the data at a certain point for debugging purposes. Languages like Haskell and PureScript have similar functions for ease of development.
 
 Composition will be our tool for constructing programs and, as luck would have it, is backed by a powerful theory that ensures things will work out for us. Let's examine this theory.
 


### PR DESCRIPTION
haskell to Haskell, purescript to PureScript, swiftz to Swiftz, and scalaz to Scalaz.

- haskell README.md:21, ch05.md:185
- Haskell ch10.md:180, ch10.md, README.md:19
- purescript README.md:21, ch05.md:185
- PureScript ch10.md:180, ch10.md:183
- scala README.md:21
- Scala ch08.md:224, ch10.md:180, README.md:19
- swift README.md:21
- Swift ch08.md:224, ch10.md:180