### PR TITLE
Remove statement that value must be an applicative

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -69,7 +69,7 @@ class Right extends Either {
 }
 ```
 
-Ah yes, if our `$value` is a functor (it must be an applicative, in fact), we can simply `map` our constructor to leap frog the type.
+Ah yes, if our `$value` is a functor (it must be, in fact), we can simply `map` our constructor to leap frog the type.
 
 You may have noticed that we've ignored the `of` entirely. It is passed in for the occasion where mapping is futile, as is the case with `Left`:
 


### PR DESCRIPTION
While its true that `$value` must be an applicative for the Traversable interface in general, the `Either` code snippet related to this sentence only requires `$value` to be a functor. 

I found the "value must be an applicative" statement to be confusing while reading, so I have taken it out. The fact that the traversable interface requires an Applicative is already prominently stated, so hopefully it's ok.