### PR TITLE
Changed the text flock_a to flockA to match the code

### DIFF
--- a/ch01.md
+++ b/ch01.md
@@ -46,7 +46,7 @@ const result = flockA
 // 32
 ```
 
-Who on earth would craft such a ghastly abomination? It is unreasonably difficult to keep track of the mutating internal state. And, good heavens, the answer is even incorrect! It should have been `16`, but `flock_a` wound up permanently altered in the process. Poor `flock_a`. This is anarchy in the I.T.! This is wild animal arithmetic!
+Who on earth would craft such a ghastly abomination? It is unreasonably difficult to keep track of the mutating internal state. And, good heavens, the answer is even incorrect! It should have been `16`, but `flockA` wound up permanently altered in the process. Poor `flockA`. This is anarchy in the I.T.! This is wild animal arithmetic!
 
 If you don't understand this program, it's okay, neither do I. The point to remember here is that state and mutable values are hard to follow, even in such a small example.
 


### PR DESCRIPTION
I changed the text `flock_a` to match up with the code example above it - `flockA`. It wasn't clear what `flock_a` referred to before.