### PR TITLE
Fix typo (peak -> peek) in appendices A, B, and C

### DIFF
--- a/appendix_a.md
+++ b/appendix_a.md
@@ -4,7 +4,7 @@ In this appendix, you'll find some basic JavaScript implementations of various f
 described in the book. Keep in mind that these implementations may not be the fastest or the
 most efficient implementation out there; they *solely serve an educational purpose*.
 
-In order to find functions that are more production-ready, have a peak at
+In order to find functions that are more production-ready, have a peek at
 [ramda](http://ramdajs.com/), [lodash](https://lodash.com/), or [folktale](http://folktale.github.io/).
 
 Note that some functions also refer to algebraic structures defined in the [Appendix B](./appendix_b.md)

--- a/appendix_b.md
+++ b/appendix_b.md
@@ -4,7 +4,7 @@ In this appendix, you'll find some basic JavaScript implementations of various a
 structures described in the book. Keep in mind that these implementations may not be the fastest or the
 most efficient implementation out there; they *solely serve an educational purpose*.
 
-In order to find structures that are more production-ready, have a peak at [folktale](http://folktale.github.io/)
+In order to find structures that are more production-ready, have a peek at [folktale](http://folktale.github.io/)
 or [fantasy-land](https://github.com/fantasyland).
 
 Note that some methods also refer to functions defined in the [Appendix A](./appendix_a.md)

--- a/appendix_c.md
+++ b/appendix_c.md
@@ -5,7 +5,7 @@ described in the book. All of the following functions are seemingly available in
 part of the global context. Keep in mind that these implementations may not be the fastest or
 the most efficient implementation out there; they *solely serve an educational purpose*.
 
-In order to find functions that are more production-ready, have a peak at
+In order to find functions that are more production-ready, have a peek at
 [ramda](http://ramdajs.com/), [lodash](https://lodash.com/), or [folktale](http://folktale.origamitower.com/).
 
 Note that functions refer to the `curry` & `compose` functions defined in [Appendix A](./appendix_a.md)


### PR DESCRIPTION
Intro text of summaries in all 3 appendices uses homophone "peak" instead of "peek" in "have a peak at..." - doesn't seem to be intentional to me, so it may be a typo.