### PR TITLE
Add npm scripts to generate epub and pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 .DS_Store
 *.md#*
 _book
+/book.pdf
+/book.epub

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm run generate-pdf
 npm run generate-epub
 ```
 
+> Note! To generate the ebook version you will need to install `ebook-convert`. [Installation instructions](https://toolchain.gitbook.com/ebook.html#installing-ebook-convert).
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ git clone https://github.com/MostlyAdequate/mostly-adequate-guide.git
 cd mostly-adequate-guide/
 npm install
 npm run setup
-gitbook pdf
+npm run generate-pdf
+npm run generate-epub
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "setup": "$(npm bin)/gitbook install",
     "start": "$(npm bin)/gitbook serve",
-    "generate-summary": "perl -n .generate-summary.pl ch*.md appendix_*.md > SUMMARY.md"
+    "generate-summary": "perl -n .generate-summary.pl ch*.md appendix_*.md > SUMMARY.md",
+    "generate-epub": "gitbook epub",
+    "generate-pdf": "gitbook pdf"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previous example in the readme is referencing a globally installed gitbook package which might not be installed on the user’s system. The new npm scripts uses the locally installed gitbook package in `node_modules`.

I also added the the generated pdf and epub file to gitignore.