### PR TITLE
fix errorneous sample code of function composition

### DIFF
--- a/ch05.md
+++ b/ch05.md
@@ -39,7 +39,7 @@ Instead of inside to outside, we run right to left, which I suppose is a step in
 
 ```js
 const head = x => x[0];
-const reverse = reduce((acc, x) => [x].concat(acc), []);
+const reverse = arr => arr.reduce((acc, x) => [x].concat(acc), []);
 const last = compose(head, reverse);
 
 last(['jumpkick', 'roundhouse', 'uppercut']); // 'uppercut'


### PR DESCRIPTION
## Objective

 The sample code of the following:

```
const head = x => x[0];
const reverse = reduce((acc, x) => [x].concat(acc), []);
const last = compose(head, reverse);

last(['jumpkick', 'roundhouse', 'uppercut']); // 'uppercut'
```

should be fixed with:

```
const head = x => x[0];
const reverse = arr => arr.reduce((acc, x) => [x].concat(acc), []);
const last = compose(head, reverse);

last(['jumpkick', 'roundhouse', 'uppercut']); // 'uppercut'

```