### PR TITLE
Removed comment on missing of class construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a book on the functional paradigm in general. We'll use the world's most
 
  * **The language is fully capable of writing top notch functional code.**
 
-    We have all the features we need to mimic a language like Scala or Haskell with the help of a tiny library or two. Object-oriented programming currently dominates the industry, but it's clearly awkward in JavaScript. It's akin to camping off of a highway or tap dancing in galoshes. We have to `bind` all over the place lest `this` change out from under us, we don't have classes (yet), we have various work arounds for the quirky behavior when the `new` keyword is forgotten, private members are only available via closures. To a lot of us, FP feels more natural anyways.
+    We have all the features we need to mimic a language like Scala or Haskell with the help of a tiny library or two. Object-oriented programming currently dominates the industry, but it's clearly awkward in JavaScript. It's akin to camping off of a highway or tap dancing in galoshes. We have to `bind` all over the place lest `this` change out from under us, we have various work arounds for the quirky behavior when the `new` keyword is forgotten, private members are only available via closures. To a lot of us, FP feels more natural anyways.
 
 That said, typed functional languages will, without a doubt, be the best place to code in the style presented by this book. JavaScript will be our means of learning a paradigm, where you apply it is up to you. Luckily, the interfaces are mathematical and, as such, ubiquitous. You'll find yourself at home with Swiftz, Scalaz, Haskell, PureScript, and other mathematically inclined environments.
 


### PR DESCRIPTION
Hey there,

Thanks for this awesome guide, I'm enjoying it a lot.
The comment in the introduction, that classes do not exist yet in JS, seemed a little bit off to me, as ES6 features classes. In addition to that, classes are also used as examples in this guide. 

For clarity it seems to be better to remove the comment on classes (unless you do not viee the current class implementation as sufficient?).

Thanks for this great read.

Kind Regards,
Florian 