### PR TITLE
Introduce the signature syntax "f x" in ch7

### DIFF
--- a/ch07.md
+++ b/ch07.md
@@ -99,11 +99,16 @@ const filter = curry((f, xs) => xs.filter(f));
 
 // reduce :: (b -> a -> b) -> b -> [a] -> b
 const reduce = curry((f, x, xs) => xs.reduce(f, x));
+
+// then :: Promise p => (a -> b) -> p a -> p b
+const then = curry((f, anyPromise) => anyPromise.then(f));
 ```
 
 `reduce` is perhaps, the most expressive of all. It's a tricky one, however, so don't feel inadequate should you struggle with it. For the curious, I'll try to explain in English though working through the signature on your own is much more instructive.
 
 Ahem, here goes nothing....looking at the signature, we see the first argument is a function that expects a `b`, an `a`, and produces a `b`. Where might it get these `a`s and `b`s? Well, the following arguments in the signature are a `b` and an array of `a`s so we can only assume that the `b` and each of those `a`s will be fed in. We also see that the result of the function is a `b` so the thinking here is our final incantation of the passed in function will be our output value. Knowing what reduce does, we can state that the above investigation is accurate.
+
+As for `then`, the `Promise p =>` tells us that `p` must be a Promise, which means that `p a` and `p b` will be promises holding `a` and `b` respectively. The same goes for other standard built-in objects such as Array.
 
 
 ## Narrowing the Possibility

--- a/ch07.md
+++ b/ch07.md
@@ -99,16 +99,11 @@ const filter = curry((f, xs) => xs.filter(f));
 
 // reduce :: (b -> a -> b) -> b -> [a] -> b
 const reduce = curry((f, x, xs) => xs.reduce(f, x));
-
-// then :: Promise p => (a -> b) -> p a -> p b
-const then = curry((f, anyPromise) => anyPromise.then(f));
 ```
 
 `reduce` is perhaps, the most expressive of all. It's a tricky one, however, so don't feel inadequate should you struggle with it. For the curious, I'll try to explain in English though working through the signature on your own is much more instructive.
 
 Ahem, here goes nothing....looking at the signature, we see the first argument is a function that expects a `b`, an `a`, and produces a `b`. Where might it get these `a`s and `b`s? Well, the following arguments in the signature are a `b` and an array of `a`s so we can only assume that the `b` and each of those `a`s will be fed in. We also see that the result of the function is a `b` so the thinking here is our final incantation of the passed in function will be our output value. Knowing what reduce does, we can state that the above investigation is accurate.
-
-As for `then`, the `Promise p =>` tells us that `p` must be a Promise, which means that `p a` and `p b` will be promises holding `a` and `b` respectively. The same goes for other standard built-in objects such as Array.
 
 
 ## Narrowing the Possibility
@@ -167,6 +162,13 @@ What we see on the left side of our fat arrow here is the statement of a fact: `
 ```
 
 Here, we have two constraints: `Eq` and `Show`. Those will ensure that we can check equality of our `a`s and print the difference if they are not equal.
+
+```
+// then :: Promise p => (a -> b) -> p a -> p b
+const then = curry((f, anyPromise) => anyPromise.then(f));
+```
+
+Finally for `then`, the `Promise p =>` tells us that `p` must be a Promise, which means that `p a` and `p b` will be promises holding `a` and `b` respectively. The same goes for other standard built-in objects such as Array.
 
 We'll see more examples of constraints and the idea should take more shape in later chapters.
 


### PR DESCRIPTION
See the following Twitter thread: https://twitter.com/drboolean/status/1056943736918167557

The signature syntax "f x" for "functor holding x" is used in chapter 8 without explanation.
We add it here and generalize it to other objects with which the reader is already familiar (like Promises or Arrays), so that when they encounter "f x" in ch8, it directly makes sense to them.