### PR TITLE
Fix nodejs deprecation warnings

### DIFF
--- a/exercises/support.js
+++ b/exercises/support.js
@@ -559,6 +559,16 @@ class Task {
   }
 }
 
+// In nodejs the existance of a class method named `inspect` will trigger a deprecation warning
+// when passing an instance to `console.log`:
+// `(node:3845) [DEP0079] DeprecationWarning: Custom inspection function on Objects via .inspect() is deprecated`
+// The solution is to alias the existing inspect method with the special inspect symbol exported by node
+if (typeof module !== 'undefined' && typeof this !== 'undefined' && this.module !== module) {
+  const customInspect = require('util').inspect.custom;
+  const assignCustomInspect = it => it.prototype[customInspect] = it.prototype.inspect;
+  [Left, Right, Identity, IO, Map, List, Maybe, Task].forEach(assignCustomInspect);
+}
+
 const identity = function identity(x) { return x; };
 
 const either = curry(function either(f, g, e) {


### PR DESCRIPTION
When I use support.js in the nodejs (v10.14.2) repl, I get lots of deprecation warnings when logging instances of classes like Maybe, Task and others. 

`(node:3845) [DEP0079] DeprecationWarning: Custom inspection function on Objects via .inspect() is deprecated`

The reason for this is the existence of a method named `inspect` in the class of the logged object. This makes the repl experience quite ugly and confusing.

A simple fix for this is to alias the inspect method with the special `util.inspect.custom` symbol which makes the warning go away. Given a class instance like `const m = Maybe('node')'`, `console.log(m)`  behaves now the same as `console.log(inspect(m))` and will output `Just('node')` instead of the warning.
