### PR TITLE
Ch12 exercise comment typo

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -267,7 +267,7 @@ Map Route Route → Task Error (Map Route JSON)
   
 {% initial src="./exercises/ch12/exercise_a.js#L11;" %}  
 ```js  
-// getRoutes :: Map Route Route -> Map Route (Task Error JSON)
+// getJsons :: Map Route Route -> Map Route (Task Error JSON)
 const getJsons = map(httpGet);
 ```  
   

--- a/exercises/ch12/exercise_a.js
+++ b/exercises/ch12/exercise_a.js
@@ -8,5 +8,5 @@
 //
 //   getJsons :: Map Route Route -> Task Error (Map Route JSON)
 
-// getRoutes :: Map Route Route -> Map Route (Task Error JSON)
+// getJsons :: Map Route Route -> Map Route (Task Error JSON)
 const getJsons = map(httpGet);


### PR DESCRIPTION
Raising a PR to correct a typo. I was reading the exercise trying to figure out what the 'getRoutes' function was but I think it looks like it simply should be 'getJsons'. Let me know if the change is incorrect.