### PR TITLE
Fixed typo: simplied => simplified

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -113,7 +113,7 @@ class Maybe {
 }
 ```
 
-Now, `Maybe` looks a lot like `Container` with one minor change: it will first check to see if it has a value before calling the supplied function. This has the effect of side stepping those pesky nulls as we `map`(Note that this implementation is simplied for teaching).
+Now, `Maybe` looks a lot like `Container` with one minor change: it will first check to see if it has a value before calling the supplied function. This has the effect of side stepping those pesky nulls as we `map`(Note that this implementation is simplified for teaching).
 
 ```js
 Maybe.of('Malkovich Malkovich').map(match(/a/ig));


### PR DESCRIPTION
Just fixed a typo. As far as I know, "simplied" does not exist.