### PR TITLE
ch9: fix HTTP upload examples

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -295,7 +295,7 @@ Let's read a file, then upload it directly afterward:
 
 ```js
 // readFile :: Filename -> Either String (Task Error String)
-// httpPost :: String -> Task Error JSON
+// httpPost :: String -> String -> Task Error JSON
 // upload :: String -> Either String (Task Error JSON)
 const upload = compose(map(chain(httpPost('/uploads'))), readFile);
 ```
@@ -314,7 +314,7 @@ const upload = (filename, callback) => {
   } else {
     readFile(filename, (errF, contents) => {
       if (errF) throw errF;
-      httpPost(contents, (errH, json) => {
+      httpPost('/uploads', contents, (errH, json) => {
         if (errH) throw errH;
         callback(json);
       });


### PR DESCRIPTION
Hi,

I've been rereading this section of the book and found this bug I thought I killed 3 years ago in #253 alive and well.

The problem here is that the two uses of function `httpPost` do not match each other and the type signature regarding the "path" parameter. The fix is to either drop this parameter or add it to the type signature and the remaining use. This patch does the latter.