### PR TITLE
ch11: fix saveComment definition

### DIFF
--- a/ch11.md
+++ b/ch11.md
@@ -27,7 +27,7 @@ Until now, we've managed to evade this common scenario with carefully crafted ex
 const saveComment = compose(
   map(map(map(postComment))),
   map(map(validate)),
-  getValue('#comment'),
+  _ => getValue('#comment'),
 );
 ```
 
@@ -169,7 +169,7 @@ const saveComment = compose(
   chain(eitherToTask),
   map(validate),
   chain(maybeToTask),
-  getValue('#comment'),
+  _ => getValue('#comment'),
 );
 ```
 


### PR DESCRIPTION
Hi,

Function `saveComment` in this chapter is defined as a composition of functions, one of which is `getValue('#comment')`. However, `getValue('#comment')` is not a function according to its type specification:

```js 
// getValue :: Selector -> Task Error (Maybe String) 
```

This patch fixes the definitions of `saveComment` to avoid type mismatch.