### PR TITLE
ch12: fix type signature of getControlNode

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -29,7 +29,7 @@ Here's one last example of a sticky situation:
 // getAttribute :: String -> Node -> Maybe String
 // $ :: Selector -> IO Node
 
-// getControlNode :: IO (Maybe (IO Node))
+// getControlNode :: Selector -> IO (Maybe (IO Node))
 const getControlNode = compose(map(map($)), map(getAttribute('aria-controls')), $);
 ```
 
@@ -166,7 +166,7 @@ Let's clean up the last example for closure (no, not that kind):
 // getAttribute :: String -> Node -> Maybe String
 // $ :: Selector -> IO Node
 
-// getControlNode :: IO (Maybe Node)
+// getControlNode :: Selector -> IO (Maybe Node)
 const getControlNode = compose(chain(traverse(IO.of, $)), map(getAttribute('aria-controls')), $);
 ```
 


### PR DESCRIPTION
Hi,

The function `getControlNode` is defined by composition, so it must have
a function type. This adds a missing parameter to its type signature.