### PR TITLE
Make nothing :: Maybe a, remove extra parameter

### DIFF
--- a/appendix_a.md
+++ b/appendix_a.md
@@ -141,8 +141,8 @@ const maybe = curry((v, f, m) => {
 ## nothing
 
 ```js
-// nothing :: () -> Maybe a
-const nothing = () => Maybe.of(null);
+// nothing :: Maybe a
+const nothing = Maybe.of(null);
 ```
 
 

--- a/exercises/ch11/solution_a.js
+++ b/exercises/ch11/solution_a.js
@@ -1,1 +1,1 @@
-const eitherToMaybe = either(_ => nothing(), Maybe.of);
+const eitherToMaybe = either(always(nothing), Maybe.of);

--- a/exercises/support.js
+++ b/exercises/support.js
@@ -579,7 +579,7 @@ const maybe = curry(function maybe(v, f, m) {
   return f(m.$value);
 });
 
-const nothing = function nothing() { return Maybe.of(null); };
+const nothing = Maybe.of(null);
 
 const reject = function reject(x) { return Task.rejected(x); };
 


### PR DESCRIPTION
`nothing` is only used in one place, and as a function it was called incorrectly before: `nothing()` instead of `nothing(undefined)`. (See https://github.com/MostlyAdequate/mostly-adequate-guide/pull/500#issuecomment-464747500.)

This PR fixes that by removing the extra layer of function wrapping entirely, and making `nothing` a constant of type `Maybe a`. This is to avoid the more verbose alternative — adding the `undefined` argument.