### PR TITLE
ch09: fix signature and usage of logFilename in exercise_b

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -438,7 +438,7 @@ basename from a filepath.
   
 {% initial src="./exercises/ch09/exercise_b.js#L13;" %}  
 ```js  
-// logFilename :: IO ()  
+// logFilename :: () -> IO ()
 const logFilename = undefined;  
   
 ```  

--- a/exercises/ch09/exercise_b.js
+++ b/exercises/ch09/exercise_b.js
@@ -10,5 +10,5 @@
 // then purely log it. Hint: you may want to use `split` and `last` to obtain the
 // basename from a filepath.
 
-// logFilename :: IO ()
+// logFilename :: () -> IO ()
 const logFilename = undefined;

--- a/exercises/ch09/validation_b.js
+++ b/exercises/ch09/validation_b.js
@@ -1,15 +1,15 @@
 /* globals logFilename */
 
 assert(
-  logFilename() instanceof IO,
-  'The function gives incorrect results; hint: `logFilename` should be an IO()',
+  logFilename(undefined) instanceof IO,
+  'The function gives incorrect results; hint: `logFilename` should return an IO()',
 );
 
-if (logFilename().unsafePerformIO() instanceof IO) {
+if (logFilename(undefined).unsafePerformIO() instanceof IO) {
   throw new Error('The function gives incorrect results; hint: make sure to `chain` effects as you go');
 }
 
 assert(
-  logFilename().unsafePerformIO() === 'ch09.md',
+  logFilename(undefined).unsafePerformIO() === 'ch09.md',
   'The function gives incorrect results; hint: did you retrieve the file\'s basename ?',
 );


### PR DESCRIPTION
This fixes type signature of function `logFilename` constructed in exercise_b, and changes its usage to match the type of the `()` parameter (see https://github.com/MostlyAdequate/mostly-adequate-guide/pull/500#issuecomment-464747500).