### PR TITLE
Improve formatting of nested chain calls in Chapter 09

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -252,8 +252,10 @@ getJSON('/authenticate', { username: 'stale', password: 'crackers' })
 
 // querySelector :: Selector -> IO DOM
 querySelector('input.username')
-  .chain(({ value: uname }) => querySelector('input.email')
-  .chain(({ value: email }) => IO.of(`Welcome ${uname} prepare for spam at ${email}`)));
+  .chain(({ value: uname }) =>
+    querySelector('input.email')
+      .chain(({ value: email }) => IO.of(`Welcome ${uname} prepare for spam at ${email}`))
+  );
 // IO('Welcome Olivia prepare for spam at olivia@tremorcontrol.net');
 
 Maybe.of(3)


### PR DESCRIPTION
The formatting of the nested `.chain` calls in Chapter 09 in one of the examples is a bit confusing to read.

Personally, when I read it I thought the `.chain` calls were consecutive which would mean that the second `.chain` call would not have access to the `uname` variable. Only when playing around with this code in an editor did I realise why this works.

This PR makes a small formatting change to make this code a little more readable.