### PR TITLE
Fix ch07

### DIFF
--- a/ch07.md
+++ b/ch07.md
@@ -97,13 +97,13 @@ const head = xs => xs[0];
 // filter :: (a -> Bool) -> [a] -> [a]
 const filter = curry((f, xs) => xs.filter(f));
 
-// reduce :: (b -> a -> b) -> b -> [a] -> b
+// reduce :: ((b, a) -> b) -> b -> [a] -> b
 const reduce = curry((f, x, xs) => xs.reduce(f, x));
 ```
 
 `reduce` is perhaps, the most expressive of all. It's a tricky one, however, so don't feel inadequate should you struggle with it. For the curious, I'll try to explain in English though working through the signature on your own is much more instructive.
 
-Ahem, here goes nothing....looking at the signature, we see the first argument is a function that expects a `b`, an `a`, and produces a `b`. Where might it get these `a`s and `b`s? Well, the following arguments in the signature are a `b` and an array of `a`s so we can only assume that the `b` and each of those `a`s will be fed in. We also see that the result of the function is a `b` so the thinking here is our final incantation of the passed in function will be our output value. Knowing what reduce does, we can state that the above investigation is accurate.
+Ahem, here goes nothing....looking at the signature, we see the first argument is a function that expects `b` and `a`, and produces a `b`. Where might it get these `a`s and `b`s? Well, the following arguments in the signature are a `b` and an array of `a`s so we can only assume that the `b` and each of those `a`s will be fed in. We also see that the result of the function is a `b` so the thinking here is our final incantation of the passed in function will be our output value. Knowing what reduce does, we can state that the above investigation is accurate.
 
 
 ## Narrowing the Possibility
@@ -163,15 +163,7 @@ What we see on the left side of our fat arrow here is the statement of a fact: `
 
 Here, we have two constraints: `Eq` and `Show`. Those will ensure that we can check equality of our `a`s and print the difference if they are not equal.
 
-```
-// then :: Promise p => (a -> b) -> p a -> p b
-const then = curry((f, anyPromise) => anyPromise.then(f));
-```
-
-Finally for `then`, the `Promise p =>` tells us that `p` must be a Promise, which means that `p a` and `p b` will be promises holding `a` and `b` respectively. The same goes for other standard built-in objects such as Array.
-
 We'll see more examples of constraints and the idea should take more shape in later chapters.
-
 
 ## In Summary
 


### PR DESCRIPTION
### Fix reduce signature

Can't give `Array.proto.reduce` a curried function. The type states that it's an array, and the implementation uses its prototype, not some custom iterating function.

### Remove Promise.then type signature 

1. Promise is not usually used as an interface. Instead, most likely it should be described as a parametrized type *(without `=>`)*.

2. `Promise`'s `.then` method is not parametrically polymorphic.

```haskell
then :: (a -> b) -> Promise a -> Promise b
then :: (a -> Promise b) -> Promise a -> Promise b
```

You can't compile such function in **Haskell**, it leads to an attempt to create an infinite type 
``` haskell
type Promise a = a | Promise a
```
which is not possible.

So better completely remove this non-parametric example.