### PR TITLE
Ch09: fix example log function in section Mixing Metaphors

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -159,7 +159,7 @@ Again, we simply remove one layer. Mind you, we have not thrown out purity, but 
 
 ```js
 // log :: a -> IO a
-const log = x => IO.of(() => {
+const log = x => new IO(() => {
   console.log(x);
   return x;
 });

--- a/ch09.md
+++ b/ch09.md
@@ -159,7 +159,7 @@ Again, we simply remove one layer. Mind you, we have not thrown out purity, but 
 
 ```js
 // log :: a -> IO a
-const log = x => new IO(() => {
+const log = x => IO.of(() => {
   console.log(x);
   return x;
 });
@@ -281,7 +281,7 @@ querySelector('input.username').chain(({ value: uname }) =>
 
 Finally, we have two examples using `Maybe`. Since `chain` is mapping under the hood, if any value is `null`, we stop the computation dead in its tracks.
 
-Don't worry if these examples are hard to grasp at first. Play with them. Poke them with a stick. Smash them to bits and reassemble. Remember to `map` when returning a "normal" value and `chain` when we're returning another functor. In the next chapter, we'll approach `Applicatives` and see nice tricks to make this kind of expressions nicer and highly readable.
+Don't worry if these examples are hard to grasp at first. Play with them. Poke them with a stick. Smash them to bits and reassemble. Remember to `map` when returning a "normal" value and `chain` when we're returning another functor. In the next chapter, we'll approach `Applicatives` and see nice tricks to make this kind of expressions nicer and highly readable. 
 
 As a reminder, this does not work with two different nested types. Functor composition and later, monad transformers, can help us in that situation.
 
@@ -401,17 +401,17 @@ const user = {
   },  
 };  
 ```  
-
+  
 {% exercise %}  
 Use `safeProp` and `map/join` or `chain` to safely get the street name when given a user  
-
+  
 {% initial src="./exercises/ch09/exercise_a.js#L16;" %}  
 ```js  
 // getStreetName :: User -> Maybe String  
 const getStreetName = undefined;  
 ```  
-
-
+  
+  
 {% solution src="./exercises/ch09/solution_a.js" %}  
 {% validation src="./exercises/ch09/validation_a.js" %}  
 {% context src="./exercises/support.js" %}  
@@ -435,15 +435,15 @@ const pureLog = str => new IO(() => console.log(str));
 Use getFile to get the filepath, remove the directory and keep only the basename,  
 then purely log it. Hint: you may want to use `split` and `last` to obtain the  
 basename from a filepath.  
-
+  
 {% initial src="./exercises/ch09/exercise_b.js#L13;" %}  
 ```js  
 // logFilename :: IO ()  
 const logFilename = undefined;  
-
+  
 ```  
-
-
+  
+  
 {% solution src="./exercises/ch09/solution_b.js" %}  
 {% validation src="./exercises/ch09/validation_b.js" %}  
 {% context src="./exercises/support.js" %}  
@@ -464,14 +464,14 @@ For this exercise, we consider helpers with the following signatures:
 Use `validateEmail`, `addToMailingList` and `emailBlast` to create a function  
 which adds a new email to the mailing list if valid, and then notify the whole  
 list.  
-
+  
 {% initial src="./exercises/ch09/exercise_c.js#L11;" %}  
 ```js  
 // joinMailingList :: Email -> Either String (IO ())  
 const joinMailingList = undefined;  
 ```  
-
-
+  
+  
 {% solution src="./exercises/ch09/solution_c.js" %}  
 {% validation src="./exercises/ch09/validation_c.js" %}  
 {% context src="./exercises/support.js" %}  

--- a/ch09.md
+++ b/ch09.md
@@ -159,7 +159,7 @@ Again, we simply remove one layer. Mind you, we have not thrown out purity, but 
 
 ```js
 // log :: a -> IO a
-const log = x => IO.of(() => {
+const log = x => new IO(() => {
   console.log(x);
   return x;
 });
@@ -281,7 +281,7 @@ querySelector('input.username').chain(({ value: uname }) =>
 
 Finally, we have two examples using `Maybe`. Since `chain` is mapping under the hood, if any value is `null`, we stop the computation dead in its tracks.
 
-Don't worry if these examples are hard to grasp at first. Play with them. Poke them with a stick. Smash them to bits and reassemble. Remember to `map` when returning a "normal" value and `chain` when we're returning another functor. In the next chapter, we'll approach `Applicatives` and see nice tricks to make this kind of expressions nicer and highly readable. 
+Don't worry if these examples are hard to grasp at first. Play with them. Poke them with a stick. Smash them to bits and reassemble. Remember to `map` when returning a "normal" value and `chain` when we're returning another functor. In the next chapter, we'll approach `Applicatives` and see nice tricks to make this kind of expressions nicer and highly readable.
 
 As a reminder, this does not work with two different nested types. Functor composition and later, monad transformers, can help us in that situation.
 
@@ -401,17 +401,17 @@ const user = {
   },  
 };  
 ```  
-  
+
 {% exercise %}  
 Use `safeProp` and `map/join` or `chain` to safely get the street name when given a user  
-  
+
 {% initial src="./exercises/ch09/exercise_a.js#L16;" %}  
 ```js  
 // getStreetName :: User -> Maybe String  
 const getStreetName = undefined;  
 ```  
-  
-  
+
+
 {% solution src="./exercises/ch09/solution_a.js" %}  
 {% validation src="./exercises/ch09/validation_a.js" %}  
 {% context src="./exercises/support.js" %}  
@@ -435,15 +435,15 @@ const pureLog = str => new IO(() => console.log(str));
 Use getFile to get the filepath, remove the directory and keep only the basename,  
 then purely log it. Hint: you may want to use `split` and `last` to obtain the  
 basename from a filepath.  
-  
+
 {% initial src="./exercises/ch09/exercise_b.js#L13;" %}  
 ```js  
 // logFilename :: IO ()  
 const logFilename = undefined;  
-  
+
 ```  
-  
-  
+
+
 {% solution src="./exercises/ch09/solution_b.js" %}  
 {% validation src="./exercises/ch09/validation_b.js" %}  
 {% context src="./exercises/support.js" %}  
@@ -464,14 +464,14 @@ For this exercise, we consider helpers with the following signatures:
 Use `validateEmail`, `addToMailingList` and `emailBlast` to create a function  
 which adds a new email to the mailing list if valid, and then notify the whole  
 list.  
-  
+
 {% initial src="./exercises/ch09/exercise_c.js#L11;" %}  
 ```js  
 // joinMailingList :: Email -> Either String (IO ())  
 const joinMailingList = undefined;  
 ```  
-  
-  
+
+
 {% solution src="./exercises/ch09/solution_c.js" %}  
 {% validation src="./exercises/ch09/validation_c.js" %}  
 {% context src="./exercises/support.js" %}  


### PR DESCRIPTION
Hello,

as a learner I got quite confused by `IO.of` instead of a constructor call in the definition of `log` in this example, because that way `log` doesn't get the correct type.
I do think it is just an erratum and should be changed to a constructor call as in later definitions of `setStyle` and `getItem`.
