### PR TITLE
Improve exercises instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ All functions and algebraic data-structures presented in the book are gathered i
 $ npm i @mostly-adequate/support
 ```
 
-Alternatively, exercises of each chapter are runnable and can be completed in your editor! For example, complete the `exercise_*.js` in `exercises/ch04` and then run:
+Alternatively, exercises of each chapter are runnable and can be completed in your editor! Firs change into the `exercises` directory and install the packages necessary run the tests against your answers.
+
+```bash
+cd exercises
+npm install
+```
+
+Then write a solution for an exercise and run the tests on it to see if you got it right. For example, complete the `exercise_*.js` in `exercises/ch04` and then run:
 
 ```bash
 $ npm run ch04


### PR DESCRIPTION
From the README, it is not clear that the user should change into the
`exercises` directory and install the dependencies there. It is
important to mention this because there is indeed a `package.json` in
the `exercises` directory with a different set of dependencies and scripts to
assert the correctness of the exercises' solutions.