### PR TITLE
Fix Hindley-Milner Comment

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -455,7 +455,7 @@ const toPairs = compose(map(split('=')), split('&'));
 // params :: String -> [[String]]
 const params = compose(toPairs, last, split('?'));
 
-// findParam :: String -> IO Maybe [String]
+// findParam :: String -> IO Maybe [[String]]
 const findParam = key => map(compose(Maybe.of, filter(compose(eq(key), head)), params), url);
 
 // -- Impure calling code ----------------------------------------------


### PR DESCRIPTION
The code just blow the example differs from the documented output see below.

// -- Impure calling code ----------------------------------------------

// run it by calling $value()!
findParam('searchTerm').$value();
// Just([['searchTerm', 'wafflehouse']])