### PR TITLE
fix reverse function by adding an arg and arrow

### DIFF
--- a/ch05.md
+++ b/ch05.md
@@ -39,7 +39,7 @@ Instead of inside to outside, we run right to left, which I suppose is a step in
 
 ```js
 const head = x => x[0];
-const reverse = reduce((acc, x) => [x].concat(acc), []);
+const reverse = xs => xs.reduce((acc, x) => [x].concat(acc), []);
 const last = compose(head, reverse);
 
 last(['jumpkick', 'roundhouse', 'uppercut']); // 'uppercut'


### PR DESCRIPTION
The reverse funciton @ line 42 was lacking an argument and the arrow or return call.

```js
const reverse = reduce((acc, x) => [x].concat(acc), []);
                 ^
ReferenceError: reduce is not defined
````

So I just fixed by changing to the following:
```js
const reverse  = xs => xs.reduce((acc, x) => [x].concat(acc), []);
```
