### PR TITLE
fix: use concat instead of append

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -312,7 +312,7 @@ Now, just like `Nothing`, we are short-circuiting our app when we return a `Left
 
 ```js
 // fortune :: Number -> String
-const fortune = compose(append('If you survive, you will be '), toString, add(1));
+const fortune = compose(concat('If you survive, you will be '), toString, add(1));
 
 // zoltar :: User -> Either(String, _)
 const zoltar = compose(map(console.log), map(fortune), getAge(moment()));


### PR DESCRIPTION
At line 315, the `fortune` function was defined using `append`, which is not compatible with the expected behavior.
This PR suggests the usage of `concat` instead of `append`, so the output of the `fortune` function would be the expected one.