### PR TITLE
Fix a typo in A Spot of Theory example

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -628,8 +628,8 @@ You see, they are equal. Next let's look at composition.
 const compLaw1 = compose(map(append(' world')), map(append(' cruel')));
 const compLaw2 = map(compose(append(' world'), append(' cruel')));
 
-compLaw1(Container.of('Goodbye')); // Container(' world cruelGoodbye')
-compLaw2(Container.of('Goodbye')); // Container(' world cruelGoodbye')
+compLaw1(Container.of('Goodbye')); // Container('Goodbye cruel world')
+compLaw2(Container.of('Goodbye')); // Container('Goodbye cruel world')
 ```
 
 In category theory, functors take the objects and morphisms of a category and map them to a different category. By definition, this new category must have an identity and the ability to compose morphisms, but we needn't check because the aforementioned laws ensure these are preserved.


### PR DESCRIPTION
Words in the example are appended, not prepended.

https://codesandbox.io/embed/confident-oskar-i4pmi