### PR TITLE
Ch08: fix findParam to make usage of Maybe reasonable

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -455,14 +455,14 @@ const toPairs = compose(map(split('=')), split('&'));
 // params :: String -> [[String]]
 const params = compose(toPairs, last, split('?'));
 
-// findParam :: String -> IO Maybe [[String]]
-const findParam = key => map(compose(Maybe.of, filter(compose(eq(key), head)), params), url);
+// findParam :: String -> IO Maybe [String]
+const findParam = key => map(compose(Maybe.of, find(compose(eq(key), head)), params), url);
 
 // -- Impure calling code ----------------------------------------------
 
 // run it by calling $value()!
 findParam('searchTerm').$value();
-// Just([['searchTerm', 'wafflehouse']])
+// Just(['searchTerm', 'wafflehouse'])
 ```
 
 Our library keeps its hands clean by wrapping `url` in an `IO` and passing the buck to the caller. You might have also noticed that we have stacked our containers; it's perfectly reasonable to have a `IO(Maybe([x]))`, which is three functors deep (`Array` is most definitely a mappable container type) and exceptionally expressive.


### PR DESCRIPTION
The text states:

> it's perfectly reasonable to have a `IO(Maybe([x]))`

But until this PR is merged, it seems not reasonable to have `Maybe` there, because there will be no `Nothing`, Only `Just []` (which does not make sense in my opinion). Also `findParam` has `find` in its name, which assumes that we expect **at most one** result from it.

Relevant changes in `findParam` function:
83ae24f392d1f5727268e199d3867fa0d902da47
acb7f35f542ad6f15ac5082d36945543ff5d8d64

Original type signature was `findParam :: String -> IO Maybe [String]`, which makes me think that `filter` was mistakingly left in code from the beginning.