### PR TITLE
fix(ch05): hint change

### DIFF
--- a/ch05.md
+++ b/ch05.md
@@ -330,7 +330,7 @@ const averageDollarValue = (cars) => {
 
 {% exercise %}  
 Refactor `fastestCar` using `compose()` and other functions in pointfree-style. Hint, the  
-`flip` function may come in handy.  
+`append` function may come in handy.  
   
 {% initial src="./exercises/ch05/exercise_c.js#L4;" %}  
 ```js  


### PR DESCRIPTION
- replace `flip` with `append`

The hint said, "Hint, the `flip` function may come in handy." After failing to make the exercise pass using flip a couple of times, I clicked to see the solution, it was using `append`. I am not sure if this hint was a red herring, but it confused me. 