### PR TITLE
update ch03.md

### DIFF
--- a/ch03.md
+++ b/ch03.md
@@ -6,7 +6,7 @@ One thing we need to get straight is the idea of a pure function.
 
 >A pure function is a function that, given the same input, will always return the same output and does not have any observable side effect.
 
-Take `slice` and `splice`. They are two functions that, whenever called passing exactly 0 and another integer, do the exact same thing - in a vastly different way, mind you, but the same thing nonetheless. We say `slice` is *pure* because it returns the same output per input every time, guaranteed. `splice`, however, will chew up its array and spit it back out forever changed which is an observable effect.
+Take `slice` and `splice`. They are two functions that, whenever called passing either exactly 0 and another integer either just one parameter, do the exact same thing - in a vastly different way, mind you, but the same thing nonetheless. We say `slice` is *pure* because it returns the same output per input every time, guaranteed. `splice`, however, will chew up its array and spit it back out forever changed which is an observable effect.
 
 ```js
 const xs = [1,2,3,4,5];

--- a/ch03.md
+++ b/ch03.md
@@ -6,7 +6,7 @@ One thing we need to get straight is the idea of a pure function.
 
 >A pure function is a function that, given the same input, will always return the same output and does not have any observable side effect.
 
-Take `slice` and `splice`. They are two functions that do the exact same thing - in a vastly different way, mind you, but the same thing nonetheless. We say `slice` is *pure* because it returns the same output per input every time, guaranteed. `splice`, however, will chew up its array and spit it back out forever changed which is an observable effect.
+Take `slice` and `splice`. They are two functions that, whenever called passing exactly 0 and another integer, do the exact same thing - in a vastly different way, mind you, but the same thing nonetheless. We say `slice` is *pure* because it returns the same output per input every time, guaranteed. `splice`, however, will chew up its array and spit it back out forever changed which is an observable effect.
 
 ```js
 const xs = [1,2,3,4,5];


### PR DESCRIPTION
Hi,
first, thx for this book... I love it
Then my cent: `slice` and `splice` have different purposes and functionality. I definitely agree that `splice` should be avoided due to its destructive nature. Anyway the only case when they (forgetting for a second about destruction side effect) have the same output is when the first parameter is exactly 0 and optionally both pass the same second integer, or, when only one parameter is passed. Not sure how to summarize that in a few words, but to avoid confusion I would at least shortly mention it.