### PR TITLE
Fix firstWords composition

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -12,7 +12,7 @@ Let's get weird:
 // readFile :: FileName -> Task Error String
 
 // firstWords :: String -> String
-const firstWords = compose(join(' '), take(3), split(' '));
+const firstWords = compose(intercalate(' '), take(3), split(' '));
 
 // tldr :: FileName -> Task Error String
 const tldr = compose(map(firstWords), readFile);
@@ -149,7 +149,7 @@ Time to revisit and clean our initial examples.
 // readFile :: FileName -> Task Error String
 
 // firstWords :: String -> String
-const firstWords = compose(join(' '), take(3), split(' '));
+const firstWords = compose(intercalate(' '), take(3), split(' '));
 
 // tldr :: FileName -> Task Error String
 const tldr = compose(map(firstWords), readFile);


### PR DESCRIPTION
The `firstWords` composition (shown below) is incorrect.

```js
// firstWords :: String -> String
const firstWords = compose(join(' '), take(3), split(' '));
```

Instead of `join(' ')` it should be `intercalate(' ')`, which calls `Array.prototype.join()` as shown in its definition:

```js
// intercalate :: String -> [String] -> String
const intercalate = curry((str, xs) => xs.join(str));
```