### PR TITLE
chore: Resize text to improve PDF readability

### DIFF
--- a/book.json
+++ b/book.json
@@ -6,5 +6,17 @@
   "plugins": [
     "exercises@git+https://github.com/MostlyAdequate/plugin-exercises.git",
     "include-codeblock@3.1.2"
-  ]
+  ],
+  "pdf": {
+    "pageNumbers": true,
+    "fontFamily": "Arial",
+    "fontSize": 20,
+    "paperSize": "a4",
+    "margin": {
+      "right": 62,
+      "left": 62,
+      "top": 56,
+      "bottom": 56
+    }
+  }
 }


### PR DESCRIPTION
Was just trying to quickly skim through the text on the reMarkable 2 and found it difficult to read on account of the small print. Basically copy pasted the pdf config settings from the https://developpaper.com/gitbook-related-configuration-and-optimization/ which should work well enough for e-reader users. Sloppy as not all setting seem to be honored, but then again... I'm just trying to quickly skim the text (and thus it is likely that this change is not worth merging but that someone may still find this PR useful as a reference and thus would be useful as a possible destination to bump into as a result of a websearch :wink:)