### PR TITLE
change folktale link to data.task

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -13,7 +13,7 @@ class Container {
   constructor(x) {
     this.$value = x;
   }
-  
+
   static of(x) {
     return new Container(x);
   }
@@ -61,13 +61,13 @@ Container.prototype.map = function (f) {
 Why, it's just like Array's famous `map`, except we have `Container a` instead of `[a]`. And it works essentially the same way:
 
 ```js
-Container.of(2).map(two => two + 2); 
+Container.of(2).map(two => two + 2);
 // Container(4)
 
-Container.of('flamethrowers').map(s => s.toUpperCase()); 
+Container.of('flamethrowers').map(s => s.toUpperCase());
 // Container('FLAMETHROWERS')
 
-Container.of('bombs').map(append(' away')).map(prop('length')); 
+Container.of('bombs').map(append(' away')).map(prop('length'));
 // Container(10)
 ```
 
@@ -169,7 +169,7 @@ const withdraw = curry((amount, { balance }) =>
   Maybe.of(balance >= amount ? { balance: balance - amount } : null));
 
 // This function is hypothetical, not implemented here... nor anywhere else.
-// updateLedger :: Account -> Account 
+// updateLedger :: Account -> Account
 const updateLedger = account => account;
 
 // remainingBalance :: Account -> String
@@ -182,7 +182,7 @@ const finishTransaction = compose(remainingBalance, updateLedger);
 // getTwenty :: Account -> Maybe(String)
 const getTwenty = compose(map(finishTransaction), withdraw(20));
 
-getTwenty({ balance: 200.00 }); 
+getTwenty({ balance: 200.00 });
 // Just('Your balance is $180')
 
 getTwenty({ balance: 10.00 });
@@ -212,10 +212,10 @@ const maybe = curry((v, f, m) => {
 // getTwenty :: Account -> String
 const getTwenty = compose(maybe('You\'re broke!', finishTransaction), withdraw(20));
 
-getTwenty({ balance: 200.00 }); 
+getTwenty({ balance: 200.00 });
 // 'Your balance is $180.00'
 
-getTwenty({ balance: 10.00 }); 
+getTwenty({ balance: 10.00 });
 // 'You\'re broke!'
 ```
 
@@ -272,10 +272,10 @@ const left = x => new Left(x);
 `Left` and `Right` are two subclasses of an abstract type we call `Either`. I've skipped the ceremony of creating the `Either` superclass as we won't ever use it, but it's good to be aware. Now then, there's nothing new here besides the two types. Let's see how they act:
 
 ```js
-Either.of('rain').map(str => `b${str}`); 
+Either.of('rain').map(str => `b${str}`);
 // Right('brain')
 
-left('rain').map(str => `It's gonna ${str}, better bring your umbrella!`); 
+left('rain').map(str => `It's gonna ${str}, better bring your umbrella!`);
 // Left('rain')
 
 Either.of({ host: 'localhost', port: 80 }).map(prop('host'));
@@ -490,11 +490,12 @@ There, much better. Now our calling code becomes `findParam('searchTerm').unsafe
 
 Callbacks are the narrowing spiral staircase to hell. They are control flow as designed by M.C. Escher. With each nested callback squeezed in between the jungle gym of curly braces and parenthesis, they feel like limbo in an oubliette (how low can we go?!). I'm getting claustrophobic chills just thinking about them. Not to worry, we have a much better way of dealing with asynchronous code and it starts with an "F".
 
-The internals are a bit too complicated to spill out all over the page here so we will use `Data.Task` (previously `Data.Future`) from Quildreen Motta's fantastic [Folktale](https://folktale.origamitower.com/). Behold some example usage:
+The internals are a bit too complicated to spill out all over the page here so we will use `Data.Task` (previously `Data.Future`) from Quildreen Motta's fantastic [data.task](https://github.com/folktale/data.task). Behold some example usage:
 
 ```js
 // -- Node readFile example ------------------------------------------
 
+const Task = require('data.task');
 const fs = require('fs');
 
 // readFile :: String -> Task Error String
@@ -502,7 +503,9 @@ const readFile = filename => new Task((reject, result) => {
   fs.readFile(filename, (err, data) => (err ? reject(err) : result(data)));
 });
 
-readFile('metamorphosis').map(split('\n')).map(head);
+readFile('metamorphosis')
+  .map(compose(split('\n'), String)) // Convert Buffer to String before split
+  .map(head);
 // Task('One morning, as Gregor Samsa was waking up from anxious dreams, he discovered that
 // in bed he had been changed into a monstrous verminous bug.')
 
@@ -713,43 +716,43 @@ What about calling a function with multiple functor arguments? How about working
 
 ## Exercises
 
-{% exercise %}  
-Use `add` and `map` to make a function that increments a value inside a functor.  
-  
-{% initial src="./exercises/ch08/exercise_a.js#L3;" %}  
-```js  
-// incrF :: Functor f => f Int -> f Int  
-const incrF = undefined;  
-```  
-  
-{% solution src="./exercises/ch08/solution_a.js" %}  
-{% validation src="./exercises/ch08/validation_a.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% exercise %}
+Use `add` and `map` to make a function that increments a value inside a functor.
+
+{% initial src="./exercises/ch08/exercise_a.js#L3;" %}
+```js
+// incrF :: Functor f => f Int -> f Int
+const incrF = undefined;
+```
+
+{% solution src="./exercises/ch08/solution_a.js" %}
+{% validation src="./exercises/ch08/validation_a.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
 
-  
-Given the following User object:  
-  
-```js  
-const user = { id: 2, name: 'Albert', active: true };  
-```  
-  
-{% exercise %}  
-Use `safeProp` and `head` to find the first initial of the user.  
-  
-{% initial src="./exercises/ch08/exercise_b.js#L7;" %}  
-```js  
-// initial :: User -> Maybe String  
-const initial = undefined;  
-```  
-  
-{% solution src="./exercises/ch08/solution_b.js" %}  
-{% validation src="./exercises/ch08/validation_b.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+
+Given the following User object:
+
+```js
+const user = { id: 2, name: 'Albert', active: true };
+```
+
+{% exercise %}
+Use `safeProp` and `head` to find the first initial of the user.
+
+{% initial src="./exercises/ch08/exercise_b.js#L7;" %}
+```js
+// initial :: User -> Maybe String
+const initial = undefined;
+```
+
+{% solution src="./exercises/ch08/solution_b.js" %}
+{% validation src="./exercises/ch08/validation_b.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
@@ -769,20 +772,20 @@ const checkActive = function checkActive(user) {
 };
 ```
 
-{% exercise %}  
+{% exercise %}
 Write a function that uses `checkActive` and `showWelcome` to grant access or return the error.
 
-{% initial src="./exercises/ch08/exercise_c.js#L15;" %}  
+{% initial src="./exercises/ch08/exercise_c.js#L15;" %}
 ```js
 // eitherWelcome :: User -> Either String String
 const eitherWelcome = undefined;
 ```
 
 
-{% solution src="./exercises/ch08/solution_c.js" %}  
-{% validation src="./exercises/ch08/validation_c.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% solution src="./exercises/ch08/solution_c.js" %}
+{% validation src="./exercises/ch08/validation_c.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
@@ -798,14 +801,14 @@ const validateUser = curry((validate, user) => validate(user).map(_ => user));
 const save = user => new IO(() => ({ ...user, saved: true }));
 ```
 
-{% exercise %}  
+{% exercise %}
 Write a function `validateName` which checks whether a user has a name longer than 3 characters
 or return an error message. Then use `either`, `showWelcome` and `save` to write a `register`
 function to signup and welcome a user when the validation is ok.
 
 Remember either's two arguments must return the same type.
 
-{% initial src="./exercises/ch08/exercise_d.js#L15;" %}  
+{% initial src="./exercises/ch08/exercise_d.js#L15;" %}
 ```js
 // validateName :: User -> Either String ()
 const validateName = undefined;
@@ -815,7 +818,7 @@ const register = compose(undefined, validateUser(validateName));
 ```
 
 
-{% solution src="./exercises/ch08/solution_d.js" %}  
-{% validation src="./exercises/ch08/validation_d.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% solution src="./exercises/ch08/solution_d.js" %}
+{% validation src="./exercises/ch08/validation_d.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}


### PR DESCRIPTION
I did not fully understand the `Task` example in chapter 8 and following the link to Folktale 2 and the new `task` implementation made me even more confused.

I tried to change the example to work with [Folktale 2](https://folktale.origamitower.com/docs/v2.3.0/migrating/from-data.task/) but I do not know what to do with the error as it does not make sense in a `cleanup` operation.

Then I found [`data.task`](https://github.com/folktale/data.task) from the same author and with one minor change to the example everything worked as expected.

I added `String` because the `data` part of the `fs.readFile` callback is a `Buffer` in node version 14. _I am not sure if was a `string` at the time of writing the example._

**I think it is far easier to follow examples if they work with the current versions of contemporary software. Since `data.task` has been published as a separate module, it should be future proof with no apparent reason for change.**

PS: My editor automatically deletes dangling spaces, therefore there is a bunch of seemingly non-changed lines. But I think it is in everyone's interest, to not have dangling spaces littering the files.