### PR TITLE
Swap append with concat in user welcome exercise (ch 8)

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -759,7 +759,7 @@ Given the following helper functions:
 
 ```js
 // showWelcome :: User -> String
-const showWelcome = compose(append('Welcome '), prop('name'));
+const showWelcome = compose(concat('Welcome '), prop('name'));
 
 // checkActive :: User -> Either String User
 const checkActive = function checkActive(user) {


### PR DESCRIPTION
Definitely a nit 😊 , but the third exercise in ch 8 would put `'Welcome '` _after_ the user's name instead of the other way around. I suspect the intention here was to use `concat` instead of `append`.

So instead of `"BrianWelcome "`   we'll have `"Welcome Brian"`.