### PR TITLE
Change `upload` param from String to Filename in ch 9

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -298,7 +298,7 @@ Let's read a file, then upload it directly afterward:
 ```js
 // readFile :: Filename -> Either String (Task Error String)
 // httpPost :: String -> String -> Task Error JSON
-// upload :: String -> Either String (Task Error JSON)
+// upload :: Filename -> Either String (Task Error JSON)
 const upload = compose(map(chain(httpPost('/uploads'))), readFile);
 ```
 
@@ -309,7 +309,7 @@ All of this is achieved in one linear left to right flow. This is all pure and d
 For contrast, let's look at the standard imperative way to pull this off:
 
 ```js
-// upload :: String -> (String -> a) -> Void
+// upload :: Filename -> (String -> a) -> Void
 const upload = (filename, callback) => {
   if (!filename) {
     throw new Error('You need a filename!');


### PR DESCRIPTION
(nit)
iiuc, `readFile`'s first param is a `Filename`, so `upload`'s first param should also be a `Filename` to be consistent/correct.