### PR TITLE
Fix endo example

### DIFF
--- a/ch13.md
+++ b/ch13.md
@@ -299,7 +299,7 @@ Endo.empty = () => Endo(identity)
 // in action
 
 // thingDownFlipAndReverse :: Endo [String] -> [String]
-const thingDownFlipAndReverse = fold(Endo(() => []), [Endo(reverse), Endo(sort), Endo(append('thing down')])
+const thingDownFlipAndReverse = fold(Endo.empty(), [Endo(reverse), Endo(sort), Endo(append('thing down')])
 
 thingDownFlipAndReverse.run(['let me work it', 'is it worth it?'])
 // ['thing down', 'let me work it', 'is it worth it?']


### PR DESCRIPTION
`thingDownFlipAndReverse` should use `Endo.empty()` as initial value.