### PR TITLE
fixed Isomorphic JavaScript example

### DIFF
--- a/ch11.md
+++ b/ch11.md
@@ -186,23 +186,23 @@ This continual and tedious sorting of types is the price we pay for having mater
 
 ## Exercises
 
-{% exercise %}
+{% exercise %}  
 Write a natural transformation that converts `Either b a` to `Maybe a`
-
-{% initial src="./exercises/ch11/exercise_a.js#L3;" %}
-```js
-// eitherToMaybe :: Either b a -> Maybe a
-const eitherToMaybe = undefined;
-```
-
-
-{% solution src="./exercises/ch11/solution_a.js" %}
-{% validation src="./exercises/ch11/validation_a.js" %}
-{% context src="./exercises/support.js" %}
-{% endexercise %}
-
-
----
+  
+{% initial src="./exercises/ch11/exercise_a.js#L3;" %}  
+```js  
+// eitherToMaybe :: Either b a -> Maybe a  
+const eitherToMaybe = undefined;  
+```  
+  
+  
+{% solution src="./exercises/ch11/solution_a.js" %}  
+{% validation src="./exercises/ch11/validation_a.js" %}  
+{% context src="./exercises/support.js" %}  
+{% endexercise %}  
+  
+  
+---  
 
 
 ```js
@@ -210,23 +210,23 @@ const eitherToMaybe = undefined;
 const eitherToTask = either(Task.rejected, Task.of);
 ```
 
-{% exercise %}
+{% exercise %}  
 Using `eitherToTask`, simplify `findNameById` to remove the nested `Either`.
-
-{% initial src="./exercises/ch11/exercise_b.js#L6;" %}
-```js
-// findNameById :: Number -> Task Error (Either Error User)
-const findNameById = compose(map(map(prop('name'))), findUserById);
-```
-
-
-{% solution src="./exercises/ch11/solution_b.js" %}
-{% validation src="./exercises/ch11/validation_b.js" %}
-{% context src="./exercises/support.js" %}
-{% endexercise %}
-
-
----
+  
+{% initial src="./exercises/ch11/exercise_b.js#L6;" %}  
+```js  
+// findNameById :: Number -> Task Error (Either Error User)  
+const findNameById = compose(map(map(prop('name'))), findUserById);  
+```  
+  
+  
+{% solution src="./exercises/ch11/solution_b.js" %}  
+{% validation src="./exercises/ch11/validation_b.js" %}  
+{% context src="./exercises/support.js" %}  
+{% endexercise %}  
+  
+  
+---  
 
 
 As a reminder, the following functions are available in the exercise's context:
@@ -236,20 +236,20 @@ split :: String -> String -> [String]
 intercalate :: String -> [String] -> String
 ```
 
-{% exercise %}
+{% exercise %}  
 Write the isomorphisms between String and [Char].
-
-{% initial src="./exercises/ch11/exercise_c.js#L8;" %}
-```js
-// strToList :: String -> [Char]
-const strToList = undefined;
-
-// listToStr :: [Char] -> String
-const listToStr = undefined;
-```
-
-
-{% solution src="./exercises/ch11/solution_c.js" %}
-{% validation src="./exercises/ch11/validation_c.js" %}
-{% context src="./exercises/support.js" %}
-{% endexercise %}
+  
+{% initial src="./exercises/ch11/exercise_c.js#L8;" %}  
+```js  
+// strToList :: String -> [Char]  
+const strToList = undefined;  
+  
+// listToStr :: [Char] -> String  
+const listToStr = undefined;  
+```  
+  
+  
+{% solution src="./exercises/ch11/solution_c.js" %}  
+{% validation src="./exercises/ch11/validation_c.js" %}  
+{% context src="./exercises/support.js" %}  
+{% endexercise %}  

--- a/ch11.md
+++ b/ch11.md
@@ -131,7 +131,7 @@ maybeToArray(arrayToMaybe(x)); // ['elvis costello']
 // but is a natural transformation
 compose(arrayToMaybe, map(replace('elvis', 'lou')))(x); // Just('lou costello')
 // ==
-compose(map(replace('elvis', 'lou'), arrayToMaybe))(x); // Just('lou costello')
+compose(map(replace('elvis', 'lou')), arrayToMaybe)(x); // Just('lou costello')
 ```
 
 They are indeed *natural transformations*, however, since `map` on either side yields the same result. I mention *isomorphisms* here, mid-chapter while we're on the subject, but don't let that fool you, they are an enormously powerful and pervasive concept. Anyways, let's move on.
@@ -186,23 +186,23 @@ This continual and tedious sorting of types is the price we pay for having mater
 
 ## Exercises
 
-{% exercise %}  
+{% exercise %}
 Write a natural transformation that converts `Either b a` to `Maybe a`
-  
-{% initial src="./exercises/ch11/exercise_a.js#L3;" %}  
-```js  
-// eitherToMaybe :: Either b a -> Maybe a  
-const eitherToMaybe = undefined;  
-```  
-  
-  
-{% solution src="./exercises/ch11/solution_a.js" %}  
-{% validation src="./exercises/ch11/validation_a.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
-  
-  
----  
+
+{% initial src="./exercises/ch11/exercise_a.js#L3;" %}
+```js
+// eitherToMaybe :: Either b a -> Maybe a
+const eitherToMaybe = undefined;
+```
+
+
+{% solution src="./exercises/ch11/solution_a.js" %}
+{% validation src="./exercises/ch11/validation_a.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
+
+
+---
 
 
 ```js
@@ -210,23 +210,23 @@ const eitherToMaybe = undefined;
 const eitherToTask = either(Task.rejected, Task.of);
 ```
 
-{% exercise %}  
+{% exercise %}
 Using `eitherToTask`, simplify `findNameById` to remove the nested `Either`.
-  
-{% initial src="./exercises/ch11/exercise_b.js#L6;" %}  
-```js  
-// findNameById :: Number -> Task Error (Either Error User)  
-const findNameById = compose(map(map(prop('name'))), findUserById);  
-```  
-  
-  
-{% solution src="./exercises/ch11/solution_b.js" %}  
-{% validation src="./exercises/ch11/validation_b.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
-  
-  
----  
+
+{% initial src="./exercises/ch11/exercise_b.js#L6;" %}
+```js
+// findNameById :: Number -> Task Error (Either Error User)
+const findNameById = compose(map(map(prop('name'))), findUserById);
+```
+
+
+{% solution src="./exercises/ch11/solution_b.js" %}
+{% validation src="./exercises/ch11/validation_b.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
+
+
+---
 
 
 As a reminder, the following functions are available in the exercise's context:
@@ -236,20 +236,20 @@ split :: String -> String -> [String]
 intercalate :: String -> [String] -> String
 ```
 
-{% exercise %}  
+{% exercise %}
 Write the isomorphisms between String and [Char].
-  
-{% initial src="./exercises/ch11/exercise_c.js#L8;" %}  
-```js  
-// strToList :: String -> [Char]  
-const strToList = undefined;  
-  
-// listToStr :: [Char] -> String  
-const listToStr = undefined;  
-```  
-  
-  
-{% solution src="./exercises/ch11/solution_c.js" %}  
-{% validation src="./exercises/ch11/validation_c.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+
+{% initial src="./exercises/ch11/exercise_c.js#L8;" %}
+```js
+// strToList :: String -> [Char]
+const strToList = undefined;
+
+// listToStr :: [Char] -> String
+const listToStr = undefined;
+```
+
+
+{% solution src="./exercises/ch11/solution_c.js" %}
+{% validation src="./exercises/ch11/validation_c.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}


### PR DESCRIPTION
Also removed trailing white-space characters.

Before this fix:
`compose(map(replace('elvis', 'lou'), arrayToMaybe))(x); // Just('lou costello')`
```
const map = curry((fn, f) => f.map(fn));
                               ^
TypeError: f.map is not a function
```

`arrayToMaybe` was used as list/array argument to `replace`. Moving `arrayToMaybe` to the right of the parenthesis, fixed the example.