### PR TITLE
fix(chapter4-exercise2): replace match function by test to fix filter…

### DIFF
--- a/ch04.md
+++ b/ch04.md
@@ -148,7 +148,7 @@ Refactor to remove all arguments by partially applying the functions.
   
 {% initial src="./exercises/ch04/exercise_b.js#L3;" %}  
 ```js  
-const filterQs = xs => filter(x => match(/q/i, x), xs);
+const filterQs = xs => filter(x => test(/q/i, x), xs);
 ```  
   
 {% solution src="./exercises/ch04/solution_b.js" %}  

--- a/exercises/ch04/exercise_b.js
+++ b/exercises/ch04/exercise_b.js
@@ -1,4 +1,4 @@
 // Refactor to remove all arguments by partially applying the functions.
 
 // filterQs :: [String] -> [String]
-const filterQs = xs => filter(x => x.match(/q/i), xs);
+const filterQs = xs => filter(x => x.test(/q/i), xs);

--- a/exercises/ch04/solution_b.js
+++ b/exercises/ch04/solution_b.js
@@ -1,1 +1,1 @@
-const filterQs = filter(match(/q/i));
+const filterQs = filter(test(/q/i));

--- a/exercises/ch04/validation_b.js
+++ b/exercises/ch04/validation_b.js
@@ -1,7 +1,7 @@
 /* globals filterQs */
 
 filter.calledPartial = false;
-match.calledPartial = false;
+test.calledPartial = false;
 
 assert.arrayEqual(
   filterQs(['quick', 'camels', 'quarry', 'over', 'quails']),
@@ -15,6 +15,6 @@ assert(
 );
 
 assert(
-  match.partially,
+  test.partially,
   'The answer is incorrect; hint: look at the arguments for `match`.',
 );


### PR DESCRIPTION
the filterQs example is incorrect. currently, `match` method is being used which returns an empty array in case of no match and `filter` method considers it as a truthy value. I have replaced `match` with `test` for intended behavior