### PR TITLE
Fix sequence section in chapter 12

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -45,7 +45,7 @@ Let's rearrange our types using `sequence`:
 sequence(List.of, Maybe.of(['the facts'])); // [Just('the facts')]
 sequence(Task.of, new Map({ a: Task.of(1), b: Task.of(2) })); // Task(Map({ a: 1, b: 2 }))
 sequence(IO.of, Either.of(IO.of('buckle my shoe'))); // IO(Right('buckle my shoe'))
-sequence(Either.of, [Either.of('wing')]); // Right(['wing'])
+sequence(List.of, Either.of(['wing'])), // List(Right('wing'))
 sequence(Task.of, left('wing')); // Task(Left('wing'))
 ```
 

--- a/support/index.js
+++ b/support/index.js
@@ -219,7 +219,7 @@ class Right extends Either {
   }
 
   traverse(of, fn) {
-    fn(this.$value).map(Either.of);
+    return fn(this.$value).map(Either.of);
   }
 }
 

--- a/support/index.js
+++ b/support/index.js
@@ -147,6 +147,7 @@ class Left extends Either {
     return `Left(${inspect(this.$value)})`;
   }
 
+
   // ----- Functor (Either a)
   map() {
     return this;
@@ -360,11 +361,16 @@ class Map {
       .reduce((acc, k) => fn(acc, this.$value[k], k), zero);
   }
 
+  // ----- Pointed Map
+  static of(x) {
+    return new Map(x);
+  }
+
   // ----- Functor (Map a)
   map(fn) {
     return this.reduceWithKeys(
       (m, v, k) => m.insert(k, fn(v)),
-      new Map({}),
+      Map.of({}),
     );
   }
 
@@ -376,7 +382,7 @@ class Map {
   traverse(of, fn) {
     return this.reduceWithKeys(
       (f, a, k) => fn(a).map(b => m => m.insert(k, b)).ap(f),
-      of(new Map({})),
+      of(Map.of({})),
     );
   }
 }

--- a/support/package.json
+++ b/support/package.json
@@ -19,7 +19,6 @@
     "guide",
     "fp"
   ],
-  "dependencies": {},
   "devDependencies": {
     "eslint": "^5.9.0",
     "eslint-config-airbnb": "^16.1.0",


### PR DESCRIPTION
This PR fixes most of the issues in #581.

From chapter 12, **Type Feng Shui** section, I have only changed line 4 from `sequence(Either.of, [Either.of('wing')]); // Right(['wing'])` to `sequence(List.of, Either.of(['wing'])), // List(Right('wing'))`, which unlike the original will not throw a TypeError. But also is an example of inverting a `Right (List (String))` to a `List (Right (String))`.
The original, `Right (List (String))` to `Right (List (String))` made little sense.

Line 5, however is not changed and does not highlight anything particular useful, since `sequence(Task.of, left('wing'))` = `Task.of(left('wing'))`.

```js
sequence(List.of, Maybe.of(['the facts'])); // [Just('the facts')]
sequence(Task.of, new Map({ a: Task.of(1), b: Task.of(2) })); // Task(Map({ a: 1, b: 2 }))
sequence(IO.of, Either.of(IO.of('buckle my shoe'))); // IO(Right('buckle my shoe'))
sequence(List.of, Either.of(['wing'])), // List(Right('wing'))
sequence(Task.of, left('wing')); // Task(Left('wing'))
```

Only two changes was required to _support/index.js_.

1. `Right`
```js
traverse(of, fn) {
  return fn(this.$value).map(Either.of); // added return
}
```
2. `Map`
```js
  // ----- Pointed Map
  static of(x) {
    return new Map(x);
  }
```
