### PR TITLE
fixing Waltz of the Types first example

### DIFF
--- a/ch12.md
+++ b/ch12.md
@@ -12,7 +12,7 @@ Let's get weird:
 // readFile :: FileName -> Task Error String
 
 // firstWords :: String -> String
-const firstWords = compose(intercalate(' '), take(3), split(' '));
+const firstWords = compose(intercalate(' '), take(3), split(' '), toString);
 
 // tldr :: FileName -> Task Error String
 const tldr = compose(map(firstWords), readFile);
@@ -149,7 +149,7 @@ Time to revisit and clean our initial examples.
 // readFile :: FileName -> Task Error String
 
 // firstWords :: String -> String
-const firstWords = compose(intercalate(' '), take(3), split(' '));
+const firstWords = compose(intercalate(' '), take(3), split(' '), toString);
 
 // tldr :: FileName -> Task Error String
 const tldr = compose(map(firstWords), readFile);

--- a/support/index.js
+++ b/support/index.js
@@ -600,7 +600,11 @@ const toUpperCase = s => s.toUpperCase();
 
 
 // traverse :: (Applicative f, Traversable t) => (a -> f a) -> (a -> f b) -> t a -> f (t b)
-const traverse = curry((of, fn, f) => f.traverse(of, fn));
+const traverse = curry((of, fn, f) =>
+  Array.isArray(f)
+    ? f.reduce((innerF, a) => fn(a).map(append).ap(innerF), of([]))
+    : f.traverse(of, fn)
+);
 
 
 // unsafePerformIO :: IO a -> a


### PR DESCRIPTION
By using the improved `traverse` function from https://github.com/MostlyAdequate/mostly-adequate-guide/issues/581#issuecomment-668274810
and adding `toString` since the nodejs `fs.readFile` returns a [`Buffer`](https://devdocs.io/node/buffer#buffer_class_buffer) and not a `String`.

```js
// readFile :: FileName -> Task Error String

// firstWords :: String -> String
const firstWords = compose(intercalate(' '), take(3), split(' '), toString);

// tldr :: FileName -> Task Error String
const tldr = compose(map(firstWords), readFile);

traverse(Task.of, tldr, ['file1', 'file2']);
// Task(['hail the monarchy', 'smash the patriarchy']);
```

Before the `traverse` function threw a `TypeError: f.traverse is not a function`, on `
traverse(Task.of, tldr, ['file1', 'file2']);`.

Thanks to @antonklimov.