### PR TITLE
Update Link To Install Ebook Convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For a best reading experience, [read it online via Gitbook](https://mostly-adequ
 
 ## Play Around with Code
 
-To make the training efficient and not get too bored while I am telling you another story, make sure to play around with the concepts introduced in this book. Some can be tricky to catch at first and are better understood by getting your hands dirty. 
+To make the training efficient and not get too bored while I am telling you another story, make sure to play around with the concepts introduced in this book. Some can be tricky to catch at first and are better understood by getting your hands dirty.
 All functions and algebraic data-structures presented in the book are gathered in the appendixes. The corresponding code is also available as an npm module:
 
 ```bash
@@ -63,7 +63,7 @@ npm run generate-pdf
 npm run generate-epub
 ```
 
-> Note! To generate the ebook version you will need to install `ebook-convert`. [Installation instructions](https://toolchain.gitbook.com/ebook.html#installing-ebook-convert).
+> Note! To generate the ebook version you will need to install `ebook-convert`. [Installation instructions](https://gitbookio.gitbooks.io/documentation/content/build/ebookconvert.html).
 
 # Table of Contents
 


### PR DESCRIPTION
This addresses [Issue #609](https://github.com/MostlyAdequate/mostly-adequate-guide/issues/609). 

I did some quick googling and came up with this link. Seems helpful in that it is informative of the fact that you need Calibre to use the CLI and is more concise about what is needed to access this particular functionality compared to Calibre's own docs which are comprehensive.

Note: 
My editor also removed a trailing whitespace.