### PR TITLE
fix: fix match reference

### DIFF
--- a/exercises/ch04/exercise_b.js
+++ b/exercises/ch04/exercise_b.js
@@ -1,4 +1,4 @@
 // Refactor to remove all arguments by partially applying the functions.
 
 // filterQs :: [String] -> [String]
-const filterQs = xs => filter(x => x.match(/q/i), xs);
+// const filterQs = xs => filter(x => match(/q/i, x), xs);


### PR DESCRIPTION
in the file, the `match` function was referenced in an erroneous way so it wasn't clear for somebody to understand how to apply partial implementation of that function.