### PR TITLE
fix regression of IO.join in chapter 9

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -178,11 +178,14 @@ We added `join` wherever we encountered the nested `Maybe`'s to keep them from g
 
 ```js
 IO.prototype.join = function() {
-  return this.unsafePerformIO();
-}
+  var thiz = this;
+  return new IO(function() {
+    return thiz.unsafePerformIO().unsafePerformIO();
+  });
+};
 ```
 
-Again, we simply remove one layer. Mind you, we have not thrown out purity, but merely removed one layer of excess shrink wrap.
+We simply bundle running the two layers of IO sequentially: outer then inner. Mind you, we have not thrown out purity, but merely repackaged the excessive two layers of shrink wrap into one easier-to-open package.
 
 ```js
 //  log :: a -> IO a


### PR DESCRIPTION
I noticed today that the IO.join() method seemed off, so I searched in issues and PRs whether someone else had spoken about this, subsequently I found this PR: https://github.com/MostlyAdequate/mostly-adequate-guide/pull/265 which had fixed the issue and this commit: https://github.com/MostlyAdequate/mostly-adequate-guide/commit/f1608d399c4045c0fe2b18824464c91e3afe9645 which reintroduced the error.

This PR is a cherry-pick of the old PR mentioned above