### PR TITLE
Ch06: Fix link to script source

### DIFF
--- a/ch06.md
+++ b/ch06.md
@@ -167,7 +167,7 @@ And we're done!
 <img src="images/cats_ss.png" alt="cats grid" />
 
 Here is the finished script:
-[include](./exercises/ch06/main.js)
+[include](https://github.com/MostlyAdequate/mostly-adequate-guide/blob/master/exercises/ch06/main.js)
 
 Now look at that. A beautifully declarative specification of what things are, not how they come to be. We now view each line as an equation with properties that hold. We can use these properties to reason about our application and refactor.
 


### PR DESCRIPTION
Fix link to script source, which was not working on the GitBook site, by using the absolute GitHub URL.